### PR TITLE
Added CoreText to RNSVG.podspec

### DIFF
--- a/RNSVG.podspec
+++ b/RNSVG.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.source_files     = 'ios/**/*.{h,m}'
   s.requires_arc     = true
   s.dependency         'React'
+  s.frameworks       = "CoreText"
 end


### PR DESCRIPTION
# Summary

Current podspec file is not listing CoreText as the target to link against, even though it's being used. It can cause issues in specific setups, e.g. when `CLANG_ENABLE_MODULES` is set to `NO` in build settings. 
Without specifying, system frameworks have to be added in post-install step manually as a workaround.
## Test Plan

I have tested this change in our project by removing current post-install step that added system framework manually and specifying it in podspec, then running `pod install` and clean build.## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
