### PR TITLE
Fix issue #1418

### DIFF
--- a/src/lib/extract/extractPolyPoints.ts
+++ b/src/lib/extract/extractPolyPoints.ts
@@ -3,7 +3,7 @@ import { NumberProp } from './types';
 export default function extractPolyPoints(points: string | NumberProp[]) {
   const polyPoints = Array.isArray(points) ? points.join(',') : points;
   return polyPoints
-    .replace(/[^e]-/, ' -')
+    .replace(/[^eE]-/, ' -')
     .split(/(?:\s+|\s*,\s*)/g)
     .join(' ');
 }


### PR DESCRIPTION
Fix bug in extractPolyPoints where an uppercase exponent (E) in a polygon (e.g. 4.7E-17) wouldn't be considered an exponent, only a lowercase one (4.7e-17)