### PR TITLE
Fix 'distance' symbol duplication with MobileVLCKit (tools.c.o).

### DIFF
--- a/ios/Utils/RNSVGPathMeasure.m
+++ b/ios/Utils/RNSVGPathMeasure.m
@@ -17,16 +17,6 @@
  */
 static CGFloat idealFlatness = (CGFloat).01;
 
-/**
- * returns the distance between two points
- */
-CGFloat distance(CGPoint p1, CGPoint p2)
-{
-    CGFloat dx = p2.x - p1.x;
-    CGFloat dy = p2.y - p1.y;
-    return hypot(dx, dy);
-}
-
 // Subdivide a Bézier (specific division)
 /*
  * (c) 2004 Alastair J. Houghton
@@ -85,10 +75,18 @@ void subdivideBezierAtT(const CGPoint bez[4], CGPoint bez1[4], CGPoint bez2[4], 
 }
 
 @implementation RNSVGPathMeasure
+/**
+* returns the distance between two points
+*/
++(CGFloat) distanceFrom:(CGPoint) p1 to:(CGPoint) p2 {
+    CGFloat dx = p2.x - p1.x;
+    CGFloat dy = p2.y - p1.y;
+    return hypot(dx, dy);
+}
 
 - (void)addLine:(CGPoint *)last next:(const CGPoint *)next {
     NSArray *line = @[[NSValue valueWithCGPoint:*last], [NSValue valueWithCGPoint:*next]];
-    _pathLength += distance(*last, *next);
+    _pathLength += [RNSVGPathMeasure distanceFrom:*last to:*next];
     [_lengths addObject:[NSNumber numberWithDouble:_pathLength]];
     [_lines addObject:line];
     *last = *next;
@@ -153,10 +151,10 @@ void subdivideBezierAtT(const CGPoint bez[4], CGPoint bez1[4], CGPoint bez2[4], 
                     CGPoint ctrl2 = bez[2];
                     CGPoint next = bez[3];
                     CGFloat polyLen =
-                        distance(last, ctrl1) +
-                        distance(ctrl1, ctrl2) +
-                        distance(ctrl2, next);
-                    CGFloat chordLen = distance(last, next);
+                        [RNSVGPathMeasure distanceFrom:last to:ctrl1] +
+                        [RNSVGPathMeasure distanceFrom:ctrl1 to:ctrl2] +
+                        [RNSVGPathMeasure distanceFrom:ctrl2 to:next];
+                    CGFloat chordLen = [RNSVGPathMeasure distanceFrom:last to:next];
                     CGFloat error = polyLen - chordLen;
 
                     // if the error is less than our accepted level of error


### PR DESCRIPTION
Related: https://github.com/xuyuanzhou/react-native-yz-vlcplayer/issues/68

thanks to @ilyapavkin


<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? 

> duplicate symbol '_distance' in:
> /Users/namtran/Library/Developer/Xcode/DerivedData/xxxxx-cnkfbfmejgwnrgdjwcktivwklalt/Build/Products/Debug-iphonesimulator/RNSVG/libRNSVG.a(RNSVGPathMeasure.o)
> /Users/namtran/Desktop/factorynowreact/ios/Pods/MobileVLCKit/MobileVLCKit-binary/MobileVLCKit.framework/MobileVLCKit(tools.c.o)
> ld: 1 duplicate symbol for architecture x86_64
> clang: error: linker command failed with exit code 1

## Test Plan

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |
| Android |    ✅    |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
