### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -919,7 +919,7 @@ The <ClipPath> SVG element defines a clipping path. A clipping path is used/refe
           x="50"
           y="30"
           fontSize="32"
-          fonWeight="bold"
+          fontWeight="bold"
           textAnchor="middle"
           scale="1.2"
         >


### PR DESCRIPTION
# Summary

Just typo in README example for ClipPath

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [x] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
