### PR TITLE
refactor: add the clip rule property to the clip path types

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -241,6 +241,7 @@ export type Circle = React.ComponentClass<CircleProps>;
 
 export interface ClipPathProps {
   id?: string;
+  clipRule?: FillRule;
 }
 export const ClipPath: React.ComponentClass<ClipPathProps>;
 export type ClipPath = React.ComponentClass<ClipPathProps>;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

I identified that one of the most important properties for the ClipPath component and that it is working perfectly, did not have its type declared in the type file. What causes warnings in the IDE's, as if declaring a non-existent type for that component, so I found the #1409 problem and corrected it by adding this missing property.

## Test Plan

I don't know what to put here, but I just added the missing type, as in the code below:
```
export type FillRule = 'evenodd' | 'nonzero';

...

export interface ClipPathProps {
  id?: string;
  clipRule?: FillRule; <- line added
}
```

### What's required for testing (prerequisites)?

Any IDE and running code

### What are the steps to reproduce (after prerequisites)?

Create code that depends on the clipRule attribute in a ClipPath component and see if the property works with or without the type

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |   ✅      |
| Android |      ✅.      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [X] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
