### PR TITLE
[other] Reduce npm package size

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,0 @@
-screenshots/
-idl/

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "react-native": "src/index.ts",
   "types": "src/index.d.ts",
   "files": [
-    "__tests__",
     "android",
     "elements",
     "ios",


### PR DESCRIPTION
# Summary

- https://npmfs.com/package/react-native-svg/12.1.0/__tests__/

**Before:**
npm notice package size:  211.4 kB                                
npm notice unpacked size: 1.0 MB  

**After:**
npm notice package size:  209.8 kB                                
npm notice unpacked size: 1.0 MB 

## Test Plan

```
npm pack --dry-run
```

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
