### PR TITLE
Fix for SvgUri and SvgCssUri crashing on non-existing svg files

### DIFF
--- a/src/xml.tsx
+++ b/src/xml.tsx
@@ -124,7 +124,7 @@ export function SvgXml(props: XmlProps) {
 
 export async function fetchText(uri: string) {
   const response = await fetch(uri);
-  return await response.text();
+  return response.ok ? await response.text() : null;
 }
 
 export function SvgUri(props: UriProps) {

--- a/src/xml.tsx
+++ b/src/xml.tsx
@@ -127,8 +127,7 @@ export async function fetchText(uri: string) {
   if (response.ok) {
     return await response.text();
   }
-  console.warn(`Fetch ${uri} failed with status ${response.status}`);
-  return null;
+  throw new Error(`Fetching ${uri} failed with status ${response.status}`);
 }
 
 export function SvgUri(props: UriProps) {

--- a/src/xml.tsx
+++ b/src/xml.tsx
@@ -124,7 +124,11 @@ export function SvgXml(props: XmlProps) {
 
 export async function fetchText(uri: string) {
   const response = await fetch(uri);
-  return response.ok ? await response.text() : null;
+  if (response.ok) {
+    return await response.text();
+  }
+  console.warn(`Fetch ${uri} failed with status ${response.status}`);
+  return null;
 }
 
 export function SvgUri(props: UriProps) {


### PR DESCRIPTION
# Summary

Fix for interpreting an HTML error response as svg data, and then crash when this cannot be parsed as well formed XML

closes #1500 

## Test Plan

n/a

### What's required for testing (prerequisites)?

Just a a clean project with the latest versions of react-native and react-native-svg

### What are the steps to reproduce (after prerequisites)?

Include this in App.js

```
<SvgUri width={100} height={100} uri={'https://dev.w3.org/SVG/tools/svgweb/samples/svg-files/ruby.svg'} />
```
and you'll get:

<img src="https://user-images.githubusercontent.com/180588/101781238-d6340a80-3af7-11eb-95c2-406814791ccc.png" width=300 />

Then make the file name invalid
```
<SvgUri width={100} height={100} uri={'https://dev.w3.org/SVG/tools/svgweb/samples/svg-files/xruby.svg'} />
```
and you'll get:

<img src="https://user-images.githubusercontent.com/180588/101781398-0ed3e400-3af8-11eb-8062-4a4cc3eee6a5.png" width=300 />

With the fix you'll get this instead:

<img src="https://user-images.githubusercontent.com/180588/101781706-725e1180-3af8-11eb-92c9-6f321070e878.png" width=300 />

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder

