### PR TITLE
Xcode 12 compatibility fix

### DIFF
--- a/RNSVG.podspec
+++ b/RNSVG.podspec
@@ -13,5 +13,5 @@ Pod::Spec.new do |s|
   s.source           = { :git => 'https://github.com/react-native-community/react-native-svg.git', :tag => "v#{s.version}" }
   s.source_files     = 'ios/**/*.{h,m}'
   s.requires_arc     = true
-  s.dependency         'React'
+  s.dependency         'React-Core'
 end


### PR DESCRIPTION
# Summary

Latest Xcode 12 fails to build while without a module to depend on React-Core directly hence this change is necessary for all native modules on iOS. For more details please check: https://github.com/facebook/react-native/issues/29633

## Test Plan

Use this branch to install with an app running on Xcode 12.
