### PR TITLE
fix: move bitmap recycling to onDetachedFromWindow

### DIFF
--- a/android/src/main/java/com/horcrux/svg/RenderableViewManager.java
+++ b/android/src/main/java/com/horcrux/svg/RenderableViewManager.java
@@ -1284,6 +1284,8 @@ class RenderableViewManager extends ViewGroupManager<VirtualView> {
             @Override
             public void onChildViewRemoved(View view, View view1) {
                 if (view instanceof VirtualView) {
+                    SvgView svgView = ((VirtualView) view).getSvgView();
+                    svgView.setRemovedFromReactViewHierarchy();
                     invalidateSvgView((VirtualView) view);
                 }
             }

--- a/android/src/main/java/com/horcrux/svg/SvgView.java
+++ b/android/src/main/java/com/horcrux/svg/SvgView.java
@@ -88,8 +88,12 @@ public class SvgView extends ReactViewGroup implements ReactCompoundView, ReactC
             }
             mRendered = false;
             ((VirtualView) parent).getSvgView().invalidate();
-            return;
         }
+    }
+
+    @Override
+    protected void onDetachedFromWindow() {
+        super.onDetachedFromWindow();
         if (mBitmap != null) {
             mBitmap.recycle();
         }

--- a/android/src/main/java/com/horcrux/svg/SvgView.java
+++ b/android/src/main/java/com/horcrux/svg/SvgView.java
@@ -66,6 +66,7 @@ public class SvgView extends ReactViewGroup implements ReactCompoundView, ReactC
     }
 
     private @Nullable Bitmap mBitmap;
+    private boolean mRemovedFromReactViewHierarchy;
 
     public SvgView(ReactContext reactContext) {
         super(reactContext);
@@ -78,6 +79,10 @@ public class SvgView extends ReactViewGroup implements ReactCompoundView, ReactC
         SvgViewManager.setSvgView(id, this);
     }
 
+    public void setRemovedFromReactViewHierarchy() {
+        mRemovedFromReactViewHierarchy = true;
+    }
+
     @Override
     public void invalidate() {
         super.invalidate();
@@ -88,6 +93,16 @@ public class SvgView extends ReactViewGroup implements ReactCompoundView, ReactC
             }
             mRendered = false;
             ((VirtualView) parent).getSvgView().invalidate();
+            return;
+        }
+        if (!mRemovedFromReactViewHierarchy) {
+            // when view is removed from the view hierarchy, we want to recycle the mBitmap when
+            // the view is detached from window, in order to preserve it for during animation, see
+            // https://github.com/react-native-svg/react-native-svg/pull/1542
+            if (mBitmap != null) {
+                mBitmap.recycle();
+            }
+            mBitmap = null;
         }
     }
 


### PR DESCRIPTION
# Summary

This PR fixes the issues in `react-native-screens` and probably other libraries using native `Fragments` for transitions on Android (see https://github.com/software-mansion/react-native-screens/issues/773). It moves the recycling and setting `mBitMap` to `null` to `onDetachedFromWindow` when the view is removed from `react` view hierarchy. `invalidate` is not always the proper place for doing it since the native view can still be visible for the user after the `invalidate` is called (see this comment with video: https://github.com/software-mansion/react-native-screens/issues/773#issuecomment-769418173).

## Test Plan

You can use the code example attached in the above comment.

### What's required for testing (prerequisites)?

The project with `svg` view and `react-native-screens` and `native-stack` navigator.

### What are the steps to reproduce (after prerequisites)?

Go back from the screen with an `svg` view.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅.      |

## Checklist

- [x] I have tested this on a simulator
