### PR TITLE
fix: Ensure gradient stop color does not become negative

### DIFF
--- a/src/lib/extract/extractGradient.ts
+++ b/src/lib/extract/extractGradient.ts
@@ -78,8 +78,8 @@ export default function extractGradient(
       );
       continue;
     }
-    const alpha = (Math.round(extractOpacity(stopOpacity) * 255) << 24) >>> 0;
-    stops.push([offsetNumber, ((color & 0x00ffffff) | alpha) >>> 0]);
+    const alpha = Math.round(extractOpacity(stopOpacity) * 255);
+    stops.push([offsetNumber, ((color & 0x00ffffff) | (alpha << 24)) >>> 0]);
   }
   stops.sort(offsetComparator);
 

--- a/src/lib/extract/extractGradient.ts
+++ b/src/lib/extract/extractGradient.ts
@@ -78,8 +78,8 @@ export default function extractGradient(
       );
       continue;
     }
-    const alpha = Math.round(extractOpacity(stopOpacity) * 255);
-    stops.push([offsetNumber, (color & 0x00ffffff) | (alpha << 24)]);
+    const alpha = (Math.round(extractOpacity(stopOpacity) * 255) << 24) >>> 0;
+    stops.push([offsetNumber, ((color & 0x00ffffff) | alpha) >>> 0]);
   }
   stops.sort(offsetComparator);
 


### PR DESCRIPTION
# Summary

The bitwise operations done in `extractGradient` can cause the stop color to become negative. This results in gradients stops becoming white or black depending on the host platform.

I'm using this library on a Windows host (https://github.com/microsoft/react-native-windows) but I believe this may also fix #1348 on iOS. I unfortunately do not have a way to test this change on an iOS device.

## Test Plan

### What's required for testing (prerequisites)?

32-bit JS host
SVG with gradient where alpha value for color stops is `0xff`

### What are the steps to reproduce (after prerequisites)?

Show SVG

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [x] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
