### PR TITLE
Remove broken enums from typescript declaration file

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -464,15 +464,6 @@ export interface UseProps extends CommonPathProps {
 export const Use: React.ComponentClass<UseProps>;
 export type Use = React.ComponentClass<UseProps>;
 
-export enum EMaskUnits {
-  USER_SPACE_ON_USE = 'userSpaceOnUse',
-  OBJECT_BOUNDING_BOX = 'objectBoundingBox',
-}
-
-export type TMaskUnits =
-  | EMaskUnits.USER_SPACE_ON_USE
-  | EMaskUnits.OBJECT_BOUNDING_BOX;
-
 export interface MaskProps extends CommonPathProps {
   id?: string;
   x?: NumberProp;
@@ -480,8 +471,8 @@ export interface MaskProps extends CommonPathProps {
   width?: NumberProp;
   height?: NumberProp;
   maskTransform?: ColumnMajorTransformMatrix | string;
-  maskUnits?: TMaskUnits;
-  maskContentUnits?: TMaskUnits;
+  maskUnits?: Units;
+  maskContentUnits?: Units;
 }
 export const Mask: React.ComponentClass<MaskProps>;
 export type Mask = React.ComponentClass<MaskProps>;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Fixes #1210 by removing the unneeded enum exports from `index.d.ts`

the `.d.ts` file doesn't actually export data – it just declares the data. If a project were to import `EMaskUnit` and reference `EMaskUnit.USER_SPACE_ON_USE`, the app would crash because `EMaskUnit` is undefined at runtime.

![Simulator Screen Shot - iPhone 12 - 2021-03-31 at 15 35 42](https://user-images.githubusercontent.com/868317/113212600-988cf600-923c-11eb-8feb-a4230766144f.png)

An alternative solution would be to export the `EMaskUnit` enum from `src/ReactNativeSVG.ts`.

## Test Plan

This PR doesn't affect any executable code – it merely updates the declaration file so that `MaskProps.maskUnits` is aligned with the underlying type.

### What's required for testing (prerequisites)?

None

### What are the steps to reproduce (after prerequisites)?

None

## Compatibility

Only changes the Typescript declaration

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] ~~I have tested this on a device and a simulator~~ (NA)
- [ ] ~~I added documentation in `README.md`~~ (NA)
- [X] I updated the typed files (typescript)
- [ ] ~~I added a test for the API in the `__tests__` folder~~ (NA)
