### PR TITLE
Fix clipRule in Android #1409

### DIFF
--- a/android/src/main/java/com/horcrux/svg/ClipPathView.java
+++ b/android/src/main/java/com/horcrux/svg/ClipPathView.java
@@ -22,7 +22,6 @@ class ClipPathView extends GroupView {
 
     public ClipPathView(ReactContext reactContext) {
         super(reactContext);
-        mClipRule = CLIP_RULE_NONZERO;
     }
 
     @Override

--- a/android/src/main/java/com/horcrux/svg/VirtualView.java
+++ b/android/src/main/java/com/horcrux/svg/VirtualView.java
@@ -342,11 +342,11 @@ abstract public class VirtualView extends ReactViewGroup {
             ClipPathView mClipNode = (ClipPathView) getSvgView().getDefinedClipPath(mClipPath);
 
             if (mClipNode != null) {
-                Path clipPath = mClipNode.mClipRule == CLIP_RULE_EVENODD ? mClipNode.getPath(canvas, paint) :
+                Path clipPath = mClipRule == CLIP_RULE_EVENODD ? mClipNode.getPath(canvas, paint) :
                         mClipNode.getPath(canvas, paint, Region.Op.UNION);
                 clipPath.transform(mClipNode.mMatrix);
                 clipPath.transform(mClipNode.mTransform);
-                switch (mClipNode.mClipRule) {
+                switch (mClipRule) {
                     case CLIP_RULE_EVENODD:
                         clipPath.setFillType(Path.FillType.EVEN_ODD);
                         break;

--- a/apple/RNSVGNode.m
+++ b/apple/RNSVGNode.m
@@ -23,7 +23,6 @@
     BOOL _transparent;
     RNSVGClipPath *_clipNode;
     CGPathRef _cachedClipPath;
-    CGImageRef _clipMask;
     CGFloat canvasWidth;
     CGFloat canvasHeight;
     CGFloat canvasDiagonal;
@@ -250,10 +249,8 @@ CGFloat const RNSVG_DEFAULT_FONT_SIZE = 12;
         return;
     }
     CGPathRelease(_cachedClipPath);
-    CGImageRelease(_clipMask);
     _cachedClipPath = nil;
     _clipPath = clipPath;
-    _clipMask = nil;
     [self invalidate];
 }
 
@@ -263,10 +260,8 @@ CGFloat const RNSVG_DEFAULT_FONT_SIZE = 12;
         return;
     }
     CGPathRelease(_cachedClipPath);
-    CGImageRelease(_clipMask);
     _cachedClipPath = nil;
     _clipRule = clipRule;
-    _clipMask = nil;
     [self invalidate];
 }
 
@@ -340,24 +335,6 @@ CGFloat const RNSVG_DEFAULT_FONT_SIZE = 12;
         }
         CGAffineTransform transform = CGAffineTransformConcat(_clipNode.matrix, _clipNode.transforms);
         _cachedClipPath = CGPathCreateCopyByTransformingPath([_clipNode getPath:context], &transform);
-        if (_clipMask) {
-            CGImageRelease(_clipMask);
-        }
-        if ([_clipNode isSimpleClipPath] || _clipNode.clipRule == kRNSVGCGFCRuleEvenodd) {
-            _clipMask = nil;
-        } else {
-            CGRect bounds = CGContextGetClipBoundingBox(context);
-            CGSize size = bounds.size;
-
-            UIGraphicsBeginImageContextWithOptions(size, NO, 0.0);
-            CGContextRef newContext = UIGraphicsGetCurrentContext();
-            CGContextTranslateCTM(newContext, 0.0, size.height);
-            CGContextScaleCTM(newContext, 1.0, -1.0);
-
-            [_clipNode renderLayerTo:newContext rect:bounds];
-            _clipMask = CGBitmapContextCreateImage(newContext);
-            UIGraphicsEndImageContext();
-        }
     }
 
     return _cachedClipPath;
@@ -368,16 +345,11 @@ CGFloat const RNSVG_DEFAULT_FONT_SIZE = 12;
     CGPathRef clipPath = [self getClipPath:context];
 
     if (clipPath) {
-        if (!_clipMask) {
-            CGContextAddPath(context, clipPath);
-            if (_clipNode.clipRule == kRNSVGCGFCRuleEvenodd) {
-                CGContextEOClip(context);
-            } else {
-                CGContextClip(context);
-            }
+        CGContextAddPath(context, clipPath);
+        if (_clipRule == kRNSVGCGFCRuleEvenodd) {
+            CGContextEOClip(context);
         } else {
-            CGRect bounds = CGContextGetClipBoundingBox(context);
-            CGContextClipToMask(context, bounds, _clipMask);
+            CGContextClip(context);
         }
     }
 }
@@ -604,9 +576,7 @@ CGFloat const RNSVG_DEFAULT_FONT_SIZE = 12;
 {
     CGPathRelease(_cachedClipPath);
     CGPathRelease(_strokePath);
-    CGImageRelease(_clipMask);
     CGPathRelease(_path);
-    _clipMask = nil;
 }
 
 @end


### PR DESCRIPTION
Fix #1409

# Summary
The `clipRule` prop should be used on graphics elements.
Not on ClipPath itself.

## Test Plan

Run example in #1409

### What's required for testing (prerequisites)?
None

### What are the steps to reproduce (after prerequisites)?
#1409

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅    |

## Checklist

- [X] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
