### PR TITLE
💄 Update package to use generated types

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
   "react-native": "src/index.ts",
-  "types": "src/index.d.ts",
+  "types": "lib/typescript/index.d.ts",
   "files": [
     "__tests__",
     "android",


### PR DESCRIPTION
# Summary

This now enables react-native-svg to use the generated types from bob. The manually edited types in src/ being incomplete.

The particular issue I was hitting is that getTotalLength is not available in src/index.d.ts

## Test Plan

```
const ref = useRef<Path>(null);
return (
 <Path
        onLayout={() => console.log(ref.current!.getTotalLength())}
        ref={ref}
  />
);
```

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [x] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
