### PR TITLE
Exclude macos files on tvOS

### DIFF
--- a/RNSVG.podspec
+++ b/RNSVG.podspec
@@ -13,6 +13,7 @@ Pod::Spec.new do |s|
   s.source            = { :git => 'https://github.com/react-native-community/react-native-svg.git', :tag => "v#{s.version}" }
   s.source_files      = 'apple/**/*.{h,m}'
   s.ios.exclude_files = '**/*.macos.{h,m}'
+  s.tvos.exclude_files = '**/*.macos.{h,m}'
   s.osx.exclude_files = '**/*.ios.{h,m}'
   s.requires_arc      = true
   s.dependency          'React'


### PR DESCRIPTION
# Summary

Including macos files will cause compile errors for tvOS app.

## Test Plan

Use react-native-svg in [react-native-tvos](https://github.com/react-native-tvos/react-native-tvos) app.
