### PR TITLE
fix#1471: every element is focusable on web

### DIFF
--- a/src/ReactNativeSVG.web.ts
+++ b/src/ReactNativeSVG.web.ts
@@ -10,6 +10,7 @@ import {
 import { NumberArray, NumberProp } from './lib/extract/types';
 import SvgTouchableMixin from './lib/SvgTouchableMixin';
 import { resolve } from './lib/resolve';
+import { getHasTouchableProperty } from './lib/util';
 
 const createElement = cE || ucE;
 
@@ -87,15 +88,10 @@ const prepare = <T extends BaseProps>(
     fontStyle,
     style,
     forwardedRef,
-    onPress,
-    onPressIn,
-    onPressOut,
-    onLongPress,
     // @ts-ignore
     ...rest
   } = props;
-  const hasTouchableProperty =
-    onPress || onPressIn || onPressOut || onLongPress;
+  const hasTouchableProperty = getHasTouchableProperty(props);
   const clean: {
     onStartShouldSetResponder?: (e: GestureResponderEvent) => boolean;
     onResponderMove?: (e: GestureResponderEvent) => void;

--- a/src/ReactNativeSVG.web.ts
+++ b/src/ReactNativeSVG.web.ts
@@ -241,7 +241,11 @@ export class WebShape<
   ) => boolean;
   constructor(props: P, context: C) {
     super(props, context);
-    SvgTouchableMixin(this);
+    const hasTouchableProperty = getHasTouchableProperty(props);
+  
+    // Do not attach touchable mixin handlers if SVG element doesn't have a touchable prop
+    if (hasTouchableProperty) SvgTouchableMixin(this);
+    
     this._remeasureMetricsOnActivation = remeasure.bind(this);
   }
 }

--- a/src/lib/SvgTouchableMixin.ts
+++ b/src/lib/SvgTouchableMixin.ts
@@ -1,5 +1,7 @@
 // @ts-ignore
 import { Touchable, GestureResponderEvent } from 'react-native';
+import { getHasTouchableProperty } from './util';
+
 const PRESS_RETENTION_OFFSET = { top: 20, left: 20, right: 20, bottom: 30 };
 // @ts-ignore
 const { Mixin } = Touchable;
@@ -121,6 +123,11 @@ const touchVals = touchKeys.map(key => SvgTouchableMixin[key]);
 const numTouchKeys = touchKeys.length;
 
 export default (target: { [x: string]: unknown; state: unknown }) => {
+  const hasTouchableProperty = getHasTouchableProperty(target.props);
+
+  // Do not attach touchable mixin handlers if SVG element doesn't have a touchable prop
+  if (!hasTouchableProperty) return;
+
   for (let i = 0; i < numTouchKeys; i++) {
     const key = touchKeys[i];
     const val = touchVals[i];

--- a/src/lib/SvgTouchableMixin.ts
+++ b/src/lib/SvgTouchableMixin.ts
@@ -1,7 +1,5 @@
 // @ts-ignore
 import { Touchable, GestureResponderEvent } from 'react-native';
-import { getHasTouchableProperty } from './util';
-
 const PRESS_RETENTION_OFFSET = { top: 20, left: 20, right: 20, bottom: 30 };
 // @ts-ignore
 const { Mixin } = Touchable;
@@ -123,11 +121,6 @@ const touchVals = touchKeys.map(key => SvgTouchableMixin[key]);
 const numTouchKeys = touchKeys.length;
 
 export default (target: { [x: string]: unknown; state: unknown }) => {
-  const hasTouchableProperty = getHasTouchableProperty(target.props);
-
-  // Do not attach touchable mixin handlers if SVG element doesn't have a touchable prop
-  if (!hasTouchableProperty) return;
-
   for (let i = 0; i < numTouchKeys; i++) {
     const key = touchKeys[i];
     const val = touchVals[i];

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -11,4 +11,10 @@ export function pickNotNil(object: { [prop: string]: unknown }) {
   return result;
 }
 
+export const getHasTouchableProperty = (props: any) => {
+  return (
+    props.onPress || props.onPressIn || props.onPressOut || props.onLongPress
+  );
+};
+
 export const idPattern = /#([^)]+)\)?$/;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->
Fixes  https://github.com/react-native-svg/react-native-svg/issues/1471
# Summary
As described in https://github.com/react-native-svg/react-native-svg/issues/1471, each SVG element is focusable/tabable on web by default. This can create issues in keyboard navigation. 
As explained by @jondkoon https://github.com/react-native-svg/react-native-svg/issues/1471#issuecomment-716953627, the TouchableMixin attaches blur handler which makes SVG elements focusable. 

So, to solve this, we only attach touchable mixin handlers if the element has any touchable props.

## Test Plan

Before:
Each element is focusable

https://user-images.githubusercontent.com/23293248/117712663-3d163680-b1f2-11eb-8887-df2cf45dae91.mov

After:
No element is focusable

https://user-images.githubusercontent.com/23293248/117712859-7fd80e80-b1f2-11eb-9f91-9cdc6d2fe59f.mov


### What's required for testing (prerequisites)?

- Render any icon on web.

### What are the steps to reproduce (after prerequisites)?
- Verify the elements are not focusable.
## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| web     |    ✅   |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
