### PR TITLE
Xcode 12 compatibility fix

### DIFF
--- a/RNSVG.podspec
+++ b/RNSVG.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.ios.exclude_files = '**/*.macos.{h,m}'
   s.osx.exclude_files = '**/*.ios.{h,m}'
   s.requires_arc      = true
-  s.dependency          'React'
+  s.dependency          'React-Core'
 end


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Latest Xcode 12 fails to build while without a module to depend on `React-Core` directly hence this change is necessary for all native modules on iOS. For more details please check: facebook/react-native#29633

Recently, all React Native modules made this necessary change.
React Native SVG is one of the latest that didn't fix this.

## Test Plan

Use this branch to install with an app running on Xcode 12.

### What's required for testing (prerequisites)?

Xcode 12 & a recent version of React Native (like 0.64)

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md` (no need)
- [ ] I updated the typed files (typescript) (no need)
- [ ] I added a test for the API in the `__tests__` folder (no need)
