### PR TITLE
Fix README re: Expo usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,11 +273,6 @@ import Svg, {
   Mask,
 } from 'react-native-svg';
 
-/* Use this if you are using Expo
-import * as Svg from 'react-native-svg';
-const { Circle, Rect } = Svg;
-*/
-
 import React from 'react';
 import { View, StyleSheet } from 'react-native';
 


### PR DESCRIPTION
It is not any different to import react-native-svg in Expo apps than it is otherwise

# Summary

README is incorrect

## Test Plan

https://snack.expo.dev/@brents/uplifting-pretzels

### What's required for testing (prerequisites)?

Run this: https://snack.expo.dev/@brents/uplifting-pretzels

Notice that you don't need to do `import * as Svg`

### What are the steps to reproduce (after prerequisites)?

n/a

## Compatibility

n/a

## Checklist

- [x] I have tested this on a device and a simulator
- [x] I added documentation in `README.md`
- [n/a] I updated the typed files (typescript)
- [n/a] I added a test for the API in the `__tests__` folder
