### PR TITLE
fix(🐛): Expose RN Transform API in types

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as ReactNative from 'react-native';
-import { GestureResponderEvent } from 'react-native';
+import { GestureResponderEvent, TransformStyle } from 'react-native';
 
 // Common props
 export type NumberProp = string | number;
@@ -203,7 +203,7 @@ export type ColumnMajorTransformMatrix = [
 ];
 
 export interface TransformProps extends TransformObject {
-  transform?: ColumnMajorTransformMatrix | string | TransformObject;
+  transform?: ColumnMajorTransformMatrix | string | TransformObject | TransformStyle["transform"];
 }
 
 export interface CommonMaskProps {


### PR DESCRIPTION
The SVG module supports the RN transform API. In fact, it is the recommended approach when animating SVG transform. This exposes the API via the TS types.