### PR TITLE
fix style attribute space

### DIFF
--- a/src/xml.tsx
+++ b/src/xml.tsx
@@ -205,7 +205,7 @@ export type Styles = { [property: string]: string };
 
 export function getStyle(string: string): Styles {
   const style: Styles = {};
-  const declarations = string.split(';');
+  const declarations = string.split(';').filter(v => v.trim());
   const { length } = declarations;
   for (let i = 0; i < length; i++) {
     const declaration = declarations[i];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

When the svg code has some blank in style attribute,like this `style="white-space: pre; "`
it was throw an error `Cannot read property 'trim' of undefined`.

## Test Plan

Test Svg Code: 
```
<?xml version="1.0" encoding="UTF-8" standalone="no" ?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="1119" height="286.47938144329896" viewBox="0 0 1119 286.47938144329896" xml:space="preserve"><g transform="matrix(1 0 0 1 296.43 94.71)" style=""  ><text xml:space="preserve" font-family="Times New Roman" font-size="48" font-style="normal" font-weight="normal" style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(255,0,0); fill-rule: nonzero; opacity: 1; white-space: pre;" ><tspan x="-168" y="15.08" style="white-space: pre; ">some text</tspan></text></g></svg>
```

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?



## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
