### PR TITLE
fix(types): Add explicit types for children

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -167,7 +167,7 @@ export interface ClipPathProps {
 }
 export const ClipPath: React.ComponentClass<ClipPathProps>;
 
-export const Defs: React.ComponentClass<{}>;
+export const Defs: React.ComponentClass<{ children?: React.ReactNode }>;
 
 export interface EllipseProps extends CommonPathProps {
   cx?: NumberProp,
@@ -200,6 +200,7 @@ export interface LineProps extends CommonPathProps {
 export const Line: React.ComponentClass<LineProps>;
 
 export interface LinearGradientProps {
+  children?: React.ReactNode,
   x1?: NumberProp,
   x2?: NumberProp,
   y1?: NumberProp,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

We plan to remove implicit types for `children` in `@types/react@18.x`. However, some of your components rely on implicit children.

Would greatly appreciate a release of 6.x so that we don't have to inline the types in the DefinitelyTyped repo

## Test Plan

Changes make the relevant failures in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210 disappear

### What's required for testing (prerequisites)?

`npm run test-all` with changes from this PR in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210

### What are the steps to reproduce (after prerequisites)?


`npm run test-all` in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [x] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
