### PR TITLE
Fix low-quality masks on iOS

### DIFF
--- a/apple/RNSVGRenderable.m
+++ b/apple/RNSVGRenderable.m
@@ -202,18 +202,23 @@ UInt32 saturate(CGFloat value) {
         CGSize boundsSize = bounds.size;
         CGFloat height = boundsSize.height;
         CGFloat width = boundsSize.width;
+        CGFloat scale = [[UIScreen mainScreen] scale];
         NSUInteger iheight = (NSUInteger)height;
         NSUInteger iwidth = (NSUInteger)width;
-        NSUInteger npixels = iheight * iwidth;
+        NSUInteger iscale = (NSUInteger)scale;
+        NSUInteger scaledHeight = iheight * iscale;
+        NSUInteger scaledWidth = iwidth * iscale;
+        NSUInteger npixels = scaledHeight * scaledWidth;
         CGRect drawBounds = CGRectMake(0, 0, width, height);
 
         // Allocate pixel buffer and bitmap context for mask
         NSUInteger bytesPerPixel = 4;
         NSUInteger bitsPerComponent = 8;
-        NSUInteger bytesPerRow = bytesPerPixel * iwidth;
+        NSUInteger bytesPerRow = bytesPerPixel * scaledWidth;
         CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
         UInt32 * pixels = (UInt32 *) calloc(npixels, sizeof(UInt32));
-        CGContextRef bcontext = CGBitmapContextCreate(pixels, iwidth, iheight, bitsPerComponent, bytesPerRow, colorSpace, kCGImageAlphaPremultipliedLast | kCGBitmapByteOrder32Big);
+        CGContextRef bcontext = CGBitmapContextCreate(pixels, scaledWidth, scaledHeight, bitsPerComponent, bytesPerRow, colorSpace, kCGImageAlphaPremultipliedLast | kCGBitmapByteOrder32Big);
+        CGContextScaleCTM(bcontext, iscale, iscale);
 
         // Clip to mask bounds and render the mask
         CGFloat x = [self relativeOn:[_maskNode x]

--- a/apple/RNSVGRenderable.m
+++ b/apple/RNSVGRenderable.m
@@ -202,7 +202,11 @@ UInt32 saturate(CGFloat value) {
         CGSize boundsSize = bounds.size;
         CGFloat height = boundsSize.height;
         CGFloat width = boundsSize.width;
+#if TARGET_OS_OSX
+        CGFloat scale = [[NSScreen mainScreen] backingScaleFactor];
+#else
         CGFloat scale = [[UIScreen mainScreen] scale];
+#endif
         NSUInteger iheight = (NSUInteger)height;
         NSUInteger iwidth = (NSUInteger)width;
         NSUInteger iscale = (NSUInteger)scale;


### PR DESCRIPTION
# Summary

This PR fixes low-quality masks on iOS, as reported in #1098.

This was caused by the bitmap for the mask being created with [CGBitmapContextCreate()](https://developer.apple.com/documentation/coregraphics/1455939-cgbitmapcontextcreate) which does not take into account the device's pixel-density, unlike [UIGraphicsBeginImageContextWithOptions()](https://developer.apple.com/documentation/uikit/1623912-uigraphicsbeginimagecontextwitho).

To fix it, the pixel-density is retrieved using `[[UIScreen mainScreen] scale]` and it is used as a scale factor for the mask bitmap.

## Test Plan

I've tested using this sample:

```jsx
<Svg width={300} height={180}>
  <Defs>
    <LinearGradient id="redGrad" x1="0" y1="0" x2="1" y2="0">
      <Stop offset="0" stopColor="#FF0000" stopOpacity="0" />
      <Stop offset="1" stopColor="#FF0000" stopOpacity="1" />
    </LinearGradient>
    <LinearGradient id="greenGrad" x1="0" y1="0" x2="1" y2="0">
      <Stop offset="0" stopColor="#00FF00" stopOpacity="0" />
      <Stop offset="1" stopColor="#00FF00" stopOpacity="1" />
    </LinearGradient>
    <LinearGradient id="blueGrad" x1="0" y1="0" x2="1" y2="0">
      <Stop offset="0" stopColor="#0000FF" stopOpacity="0" />
      <Stop offset="1" stopColor="#0000FF" stopOpacity="1" />
    </LinearGradient>
    <Mask
      id="mask"
      x="0"
      y="0"
      width="300"
      height="180"
    >
      <Text
        fill="url(#redGrad)"
        fontSize="40"
        fontWeight="bold"
        x="20"
        y="45"
      >
        TEST MASK
      </Text>
      <Text
        fill="url(#greenGrad)"
        fontSize="40"
        fontWeight="bold"
        x="20"
        y="105"
      >
        TEST MASK
      </Text>
      <Text
        fill="url(#blueGrad)"
        fontSize="40"
        fontWeight="bold"
        x="20"
        y="165"
      >
        TEST MASK
      </Text>
    </Mask>
  </Defs>
  <Rect x="0" y="0" width="300" height="180" fill="red" mask="url(#mask)" />
</Svg>
```

**Results:**

| Before | After |
|-------|------|
| ![Simulator Screen Shot - iPhone 13 - 2021-10-25 at 23 15 36](https://user-images.githubusercontent.com/20420653/138926431-49625556-4dba-42d1-84fc-0abd5569f83f.png) | ![Simulator Screen Shot - iPhone 13 - 2021-10-25 at 23 19 28](https://user-images.githubusercontent.com/20420653/138926530-fae510eb-c4b2-43e9-bc76-53bdd7763b89.png) |

