### PR TITLE
feat: add empty CI job so it runs on PR then

### DIFF
--- a/.github/workflows/macos-build-test.yml
+++ b/.github/workflows/macos-build-test.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       WORKING_DIRECTORY: Example
     concurrency:
-      group: ios-${{ github.ref }}
+      group: macos-${{ github.ref }}
       cancel-in-progress: true
     steps:
       - name: checkout

--- a/.github/workflows/macos-build-test.yml
+++ b/.github/workflows/macos-build-test.yml
@@ -1,0 +1,22 @@
+name: Test iOS build
+on:
+  pull_request:
+    branches:
+      - develop
+    paths:
+      - 'apple/**'
+  push:
+    branches:
+      - develop
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: macos-latest
+    env:
+      WORKING_DIRECTORY: Example
+    concurrency:
+      group: ios-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2

--- a/.github/workflows/macos-build-test.yml
+++ b/.github/workflows/macos-build-test.yml
@@ -1,4 +1,4 @@
-name: Test iOS build
+name: Test macOS build
 on:
   pull_request:
     branches:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Added empty CI job for building macOS so it can be run on the proper PR: https://github.com/react-native-svg/react-native-svg/pull/1704