### PR TITLE
fix: change ci jobs to main

### DIFF
--- a/.github/workflows/android-build-test.yml
+++ b/.github/workflows/android-build-test.yml
@@ -2,12 +2,12 @@ name: Test Android build
 on:
   pull_request:
     branches:
-      - develop
+      - main
     paths:
       - 'android/**'
   push:
     branches:
-      - develop
+      - main
   workflow_dispatch:
 jobs:
   build:

--- a/.github/workflows/ios-build-test.yml
+++ b/.github/workflows/ios-build-test.yml
@@ -2,12 +2,12 @@ name: Test iOS build
 on:
   pull_request:
     branches:
-      - develop
+      - main
     paths:
       - 'apple/**'
   push:
     branches:
-      - develop
+      - main
   workflow_dispatch:
 jobs:
   build:

--- a/.github/workflows/macos-build-test.yml
+++ b/.github/workflows/macos-build-test.yml
@@ -2,12 +2,12 @@ name: Test macOS build
 on:
   pull_request:
     branches:
-      - develop
+      - main
     paths:
       - 'apple/**'
   push:
     branches:
-      - develop
+      - main
   workflow_dispatch:
 jobs:
   build:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

PR changing CI jobs target to `main` branch since it was changed from `develop`.