### PR TITLE
Add support for setting an onError prop on SvgCssUri

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,29 @@ export default () => (
 );
 ```
 
+#### Error handling
+
+Both `SvgUri` and `SvgCssUri` log errors to the console, but otherwise ignore them.
+You can set property `onError` if you want to handle errors such as resource not
+existing in a different way.
+
+```jsx
+import * as React from 'react';
+import { SvgUri } from 'react-native-svg';
+
+export default () => {
+  const [uri, setUri] = React.useState('https://dev.w3.org/SVG/tools/svgweb/samples/svg-files/not_existing.svg')
+  return (
+    <SvgUri
+      onError={() => setUri('https://dev.w3.org/SVG/tools/svgweb/samples/svg-files/ruby.svg')}
+      width="100%"
+      height="100%"
+      uri={uri}
+    />
+  );
+}
+```
+
 ### Use with svg files
 
 Try [react-native-svg-transformer](https://github.com/kristerkari/react-native-svg-transformer) to get compile time conversion and cached transformations.

--- a/TestsExample/src/SampleTest.tsx
+++ b/TestsExample/src/SampleTest.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { Platform, Button, SafeAreaView } from 'react-native';
+import { PlatformColor, Platform, Button } from 'react-native';
 import {
   Svg,
   Circle,
   Rect,
   Text,
   TSpan,
-  SvgCssUri
+  SvgUri
 } from 'react-native-svg';
 
 const color = PlatformColor(Platform.select({
@@ -46,7 +46,7 @@ export default () => {
         </Text>
       </Svg>
       <Button title="Click me" onPress={()=> setTest(test + 1)}/>
-      <SvgCssUri
+      <SvgUri
         onError={() => setUri('https://dev.w3.org/SVG/tools/svgweb/samples/svg-files/ruby.svg')}
         width="100"
         height="100"

--- a/TestsExample/src/SampleTest.tsx
+++ b/TestsExample/src/SampleTest.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { PlatformColor, Platform, Button } from 'react-native';
+import { Platform, Button, SafeAreaView } from 'react-native';
 import {
   Svg,
   Circle,
   Rect,
   Text,
-  TSpan
+  TSpan,
+  SvgCssUri
 } from 'react-native-svg';
 
 const color = PlatformColor(Platform.select({
@@ -16,6 +17,7 @@ const color = PlatformColor(Platform.select({
 
 export default () => {
   const [test, setTest] = React.useState(50);
+  const [uri, setUri] = React.useState('https://dev.w3.org/SVG/tools/svgweb/samples/svg-files/not_existing.svg')
 
   return (
     <>
@@ -44,6 +46,12 @@ export default () => {
         </Text>
       </Svg>
       <Button title="Click me" onPress={()=> setTest(test + 1)}/>
+      <SvgCssUri
+        onError={() => setUri('https://dev.w3.org/SVG/tools/svgweb/samples/svg-files/ruby.svg')}
+        width="100"
+        height="100"
+        uri={uri}
+      />
     </>
   );
 }

--- a/src/css.tsx
+++ b/src/css.tsx
@@ -692,15 +692,15 @@ export function SvgCss(props: XmlProps) {
 }
 
 export function SvgCssUri(props: UriProps) {
-  const { uri } = props;
+  const { uri, onError = err } = props;
   const [xml, setXml] = useState<string | null>(null);
   useEffect(() => {
     uri
       ? fetchText(uri)
           .then(setXml)
-          .catch(err)
+          .catch(onError)
       : setXml(null);
-  }, [uri]);
+  }, [onError, uri]);
   return <SvgCss xml={xml} override={props} />;
 }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -393,7 +393,12 @@ export interface StopProps {
 export const Stop: React.ComponentClass<StopProps>;
 export type Stop = React.ComponentClass<StopProps>;
 
-export interface SvgProps extends GProps, ReactNative.ViewProperties {
+export type AdditionalProps = {
+  onError?: (error: Error) => void;
+  override?: Object;
+};
+
+export interface SvgProps extends AdditionalProps, GProps, ReactNative.ViewProperties {
   width?: NumberProp;
   height?: NumberProp;
   viewBox?: string;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -393,12 +393,7 @@ export interface StopProps {
 export const Stop: React.ComponentClass<StopProps>;
 export type Stop = React.ComponentClass<StopProps>;
 
-export type AdditionalProps = {
-  onError?: (error: Error) => void;
-  override?: Object;
-};
-
-export interface SvgProps extends AdditionalProps, GProps, ReactNative.ViewProperties {
+export interface SvgProps extends GProps, ReactNative.ViewProperties {
   width?: NumberProp;
   height?: NumberProp;
   viewBox?: string;
@@ -549,12 +544,14 @@ export interface JsxAST extends AST {
 
 export interface UriProps extends SvgProps {
   uri: string | null;
+  onError?: (error: Error) => void;
   override?: SvgProps;
 }
 export type UriState = { xml: string | null };
 
 export interface XmlProps extends SvgProps {
   xml: string | null;
+  onError?: (error: Error) => void;
   override?: SvgProps;
 }
 export type XmlState = { ast: JsxAST | null };

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -349,11 +349,6 @@ export interface StopProps {
 }
 declare export var Stop: React.ComponentClass<StopProps>;
 export type StopType = React.ComponentClass<StopProps>;
-export type AdditionalProps = {
-  onError?: (error: Error) => void,
-  override?: Object,
-  ...
-};
 export type SvgProps = {
   width?: NumberProp,
   height?: NumberProp,
@@ -362,8 +357,7 @@ export type SvgProps = {
   color?: Color,
   title?: string,
   ...
-} & AdditionalProps &
-  GProps &
+} & GProps &
   ReactNative.ViewProperties;
 declare export var Svg: React.ComponentClass<SvgProps>;
 export type SvgType = React.ComponentClass<SvgProps>;
@@ -507,6 +501,7 @@ export type JsxAST = {
 } & AST;
 export type UriProps = {
   uri: string | null,
+  onError?: (error: Error) => void,
   override?: SvgProps,
   ...
 } & SvgProps;
@@ -516,6 +511,7 @@ export type UriState = {
 };
 export type XmlProps = {
   xml: string | null,
+  onError?: (error: Error) => void,
   override?: SvgProps,
   ...
 } & SvgProps;

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -349,6 +349,11 @@ export interface StopProps {
 }
 declare export var Stop: React.ComponentClass<StopProps>;
 export type StopType = React.ComponentClass<StopProps>;
+export type AdditionalProps = {
+  onError?: (error: Error) => void,
+  override?: Object,
+  ...
+};
 export type SvgProps = {
   width?: NumberProp,
   height?: NumberProp,
@@ -357,7 +362,8 @@ export type SvgProps = {
   color?: Color,
   title?: string,
   ...
-} & GProps &
+} & AdditionalProps &
+  GProps &
   ReactNative.ViewProperties;
 declare export var Svg: React.ComponentClass<SvgProps>;
 export type SvgType = React.ComponentClass<SvgProps>;


### PR DESCRIPTION
# Summary

In PR #1266, support was added for setting an `onError` property on `SvgUri`. This PR adds the same to `SvgCssUri`.

## Test Plan

This should now work: 

```ts
import React, {Component} from 'react';
import {  SvgCssUri } from 'react-native-svg';

class Example extends Component {

    state={
      uri: 'https://dev.w3.org/SVG/tools/svgweb/samples/svg-files/xruby.svg',
    }

    render() {
        return (
            <SvgCssUri width={100} onError={() => this.setState({uri: 'https://dev.w3.org/SVG/tools/svgweb/samples/svg-files/ruby.svg'})} height={100} uri={this.state.uri} />
        );
    }
}
```

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder

## Note

This PR is on request from @WoLewicki in PR #1503.

