### PR TITLE
fix: Handle hex colors that does not start with "#" or "0x".

### DIFF
--- a/src/lib/extract/extractBrush.ts
+++ b/src/lib/extract/extractBrush.ts
@@ -30,6 +30,10 @@ export default function extractBrush(color?: Color) {
     return contextStrokeBrush;
   }
 
+  if (typeof color === 'string' && color.match(/^[0-9a-f]{6}$/)) {
+    return integerColor(parseInt(color, 16));
+  }
+
   const brush = typeof color === 'string' && color.match(urlIdPattern);
   if (brush) {
     return [1, brush[1]];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
Minor partial fix of #1740 . This PR fixes the issue with colors containing a hex value, but without the `#`or `0x` start.

## Test Plan

I have not managed to get a local version of the library to work in my test app, so could not take on the major parts of the issue.
### What's required for testing (prerequisites)?
A value of `fill="888888"`

### What are the steps to reproduce (after prerequisites)?
Render the SVG with the color.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
