### PR TITLE
Fix Stop.tsx error TS2612: Property 'props' will overwrite the base property in 'Component<StopProps, {}, any>'

### DIFF
--- a/src/elements/Stop.tsx
+++ b/src/elements/Stop.tsx
@@ -5,7 +5,6 @@ type StopProps = {
 };
 
 export default class Stop extends Component<StopProps, {}> {
-  props!: StopProps;
   static displayName = 'Stop';
 
   setNativeProps = () => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Hi, not sure why this has props declared here (`Component<StopProps, {}>` handles that) and it results in a TS error (TS 4.7.2):

```
node_modules/react-native-svg/src/elements/Stop.tsx:8:3 - error TS2612: Property 'props' will overwrite the base property in 'Component<StopProps, {}, any>'. If this is intentional, add an initializer. Otherwise, add a 'declare' modifier or remove the redundant declaration.

8   props!: StopProps;
    ~~~~~

Found 1 error. Watching for file changes.
```

## Test Plan

`tsc` passes but other lint/test tasks fail for unrelated reasons

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [x] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
