### PR TITLE
Change enum declaration in `index.d.ts` to UnionType

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -468,15 +468,6 @@ export interface UseProps extends CommonPathProps {
 export const Use: React.ComponentClass<UseProps>;
 export type Use = React.ComponentClass<UseProps>;
 
-export enum EMaskUnits {
-  USER_SPACE_ON_USE = 'userSpaceOnUse',
-  OBJECT_BOUNDING_BOX = 'objectBoundingBox',
-}
-
-export type TMaskUnits =
-  | EMaskUnits.USER_SPACE_ON_USE
-  | EMaskUnits.OBJECT_BOUNDING_BOX;
-
 export interface MaskProps extends CommonPathProps {
   id?: string;
   x?: NumberProp;
@@ -484,8 +475,8 @@ export interface MaskProps extends CommonPathProps {
   width?: NumberProp;
   height?: NumberProp;
   maskTransform?: ColumnMajorTransformMatrix | string;
-  maskUnits?: TMaskUnits;
-  maskContentUnits?: TMaskUnits;
+  maskUnits?: Units;
+  maskContentUnits?: Units;
 }
 export const Mask: React.ComponentClass<MaskProps>;
 export type Mask = React.ComponentClass<MaskProps>;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -8,6 +8,8 @@ export type NumberArray = NumberProp[] | NumberProp;
 
 export type FillRule = 'evenodd' | 'nonzero';
 export type Units = 'userSpaceOnUse' | 'objectBoundingBox';
+export type MarkerUnits = 'strokeWidth' | 'userSpaceOnUse';
+export type Orient = 'auto' | 'auto-start-reverse';
 
 export type TextAnchor = 'start' | 'middle' | 'end';
 export type FontStyle = 'normal' | 'italic' | 'oblique';
@@ -480,16 +482,6 @@ export interface MaskProps extends CommonPathProps {
 }
 export const Mask: React.ComponentClass<MaskProps>;
 export type Mask = React.ComponentClass<MaskProps>;
-
-export enum MarkerUnits {
-  STROKE_WIDTH = 'strokeWidth',
-  USER_SPACE_ON_USE = 'userSpaceOnUse',
-}
-
-export enum Orient {
-  AUTO = 'auto',
-  AUTO_START_REVERSE = 'auto-start-reverse',
-}
 
 export interface MarkerProps {
   id?: string;

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -15,6 +15,8 @@ export type NumberProp = string | number;
 export type NumberArray = NumberProp[] | NumberProp;
 export type FillRule = "evenodd" | "nonzero";
 export type Units = "userSpaceOnUse" | "objectBoundingBox";
+export type MarkerUnits = "strokeWidth" | "userSpaceOnUse";
+export type Orient = "auto" | "auto-start-reverse";
 export type TextAnchor = "start" | "middle" | "end";
 export type FontStyle = "normal" | "italic" | "oblique";
 export type FontVariant = "normal" | "small-caps";
@@ -230,7 +232,8 @@ export type EllipseType = React.ComponentClass<EllipseProps>;
 export type GProps = {
   opacity?: NumberProp,
   ...
-} & CommonPathProps;
+} & CommonPathProps &
+  FontProps;
 declare export var G: React.ComponentClass<GProps>;
 export type GType = React.ComponentClass<GProps>;
 export interface ForeignObjectProps {
@@ -430,13 +433,6 @@ export type UseProps = {
 } & CommonPathProps;
 declare export var Use: React.ComponentClass<UseProps>;
 export type UseType = React.ComponentClass<UseProps>;
-declare export var EMaskUnits: {|
-  +USER_SPACE_ON_USE: "userSpaceOnUse", // "userSpaceOnUse"
-  +OBJECT_BOUNDING_BOX: "objectBoundingBox", // "objectBoundingBox"
-|};
-export type TMaskUnits =
-  | typeof EMaskUnits.USER_SPACE_ON_USE
-  | typeof EMaskUnits.OBJECT_BOUNDING_BOX;
 export type MaskProps = {
   id?: string,
   x?: NumberProp,
@@ -444,21 +440,12 @@ export type MaskProps = {
   width?: NumberProp,
   height?: NumberProp,
   maskTransform?: ColumnMajorTransformMatrix | string,
-  maskUnits?: TMaskUnits,
-  maskContentUnits?: TMaskUnits,
+  maskUnits?: Units,
+  maskContentUnits?: Units,
   ...
 } & CommonPathProps;
 declare export var Mask: React.ComponentClass<MaskProps>;
 export type MaskType = React.ComponentClass<MaskProps>;
-declare export var MarkerUnits: {|
-  +STROKE_WIDTH: "strokeWidth", // "strokeWidth"
-  +USER_SPACE_ON_USE: "userSpaceOnUse", // "userSpaceOnUse"
-|};
-
-declare export var Orient: {|
-  +AUTO: "auto", // "auto"
-  +AUTO_START_REVERSE: "auto-start-reverse", // "auto-start-reverse"
-|};
 export interface MarkerProps {
   id?: string;
   viewBox?: string;
@@ -467,8 +454,8 @@ export interface MarkerProps {
   refY?: NumberProp;
   markerWidth?: NumberProp;
   markerHeight?: NumberProp;
-  markerUnits?: $Values<typeof MarkerUnits>;
-  orient?: $Values<typeof Orient> | NumberProp;
+  markerUnits?: MarkerUnits;
+  orient?: Orient | NumberProp;
 }
 declare export var Marker: React.ComponentClass<MarkerProps>;
 export type MarkerType = React.ComponentClass<MarkerProps>;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
Fixes #1210 

This PR is in addition to #1559 by @avery-pierce .

As https://github.com/react-native-svg/react-native-svg/pull/1559#issuecomment-983162634 commented, it should be better to remove all enum from `index.d.ts`, `MarkerUnits` and `Orient`.
Because these did not have an already defined UnionType like MaskUnit, we created a new one.

<!-- 
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan
This PR doesn't affect any executable code.
This correspondence only changes `index.d.ts` and its accompanying index.js.flow.

### What's required for testing (prerequisites)?
None

### What are the steps to reproduce (after prerequisites)?
None

## Compatibility
Only changes the Typescript declaration

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [x] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder


> **Note**
> This is my first pull request for OSS project. If you see something not good, please feel free advice me :)

