### PR TITLE
fix: remove tsignore in LocalSvg and provide correct types

### DIFF
--- a/src/LocalSvg.tsx
+++ b/src/LocalSvg.tsx
@@ -1,7 +1,5 @@
 import React, { useState, useEffect, Component } from 'react';
-import { NativeModules, Platform } from 'react-native';
-// @ts-ignore
-import resolveAssetSource from 'react-native/Libraries/Image/resolveAssetSource';
+import { NativeModules, Platform, Image, ImageSourcePropType } from 'react-native';
 
 import { fetchText } from './xml';
 import { SvgCss, SvgWithCss } from './css';
@@ -9,21 +7,21 @@ import { SvgProps } from './elements/Svg';
 
 const { getRawResource } = NativeModules.RNSVGRenderableManager || {};
 
-export function getUriFromSource(source?: string | number) {
-  const resolvedAssetSource = resolveAssetSource(source);
+export function getUriFromSource(source: ImageSourcePropType) {
+  const resolvedAssetSource = Image.resolveAssetSource(source);
   return resolvedAssetSource.uri;
 }
 
-export function loadLocalRawResourceDefault(source?: string | number) {
+export function loadLocalRawResourceDefault(source: ImageSourcePropType) {
   const uri = getUriFromSource(source);
   return fetchText(uri);
 }
 
-export function isUriAnAndroidResourceIdentifier(uri?: string | number) {
+export function isUriAnAndroidResourceIdentifier(uri?: string) {
   return typeof uri === 'string' && uri.indexOf('/') <= -1;
 }
 
-export async function loadAndroidRawResource(uri?: string | number) {
+export async function loadAndroidRawResource(uri: string) {
   try {
     return await getRawResource(uri);
   } catch (e) {
@@ -35,7 +33,7 @@ export async function loadAndroidRawResource(uri?: string | number) {
   }
 }
 
-export function loadLocalRawResourceAndroid(source?: string | number) {
+export function loadLocalRawResourceAndroid(source: ImageSourcePropType) {
   const uri = getUriFromSource(source);
   if (isUriAnAndroidResourceIdentifier(uri)) {
     return loadAndroidRawResource(uri);
@@ -50,7 +48,7 @@ export const loadLocalRawResource =
     : loadLocalRawResourceAndroid;
 
 export type LocalProps = SvgProps & {
-  asset?: string | number;
+  asset: ImageSourcePropType;
   override?: Object;
 };
 export type LocalState = { xml: string | null };
@@ -69,13 +67,13 @@ export class WithLocalSvg extends Component<LocalProps, LocalState> {
   componentDidMount() {
     this.load(this.props.asset);
   }
-  componentDidUpdate(prevProps: { asset?: string | number }) {
+  componentDidUpdate(prevProps: { asset: ImageSourcePropType }) {
     const { asset } = this.props;
     if (asset !== prevProps.asset) {
       this.load(asset);
     }
   }
-  async load(asset?: string | number) {
+  async load(asset: ImageSourcePropType) {
     try {
       this.setState({ xml: asset ? await loadLocalRawResource(asset) : null });
     } catch (e) {

--- a/src/LocalSvg.tsx
+++ b/src/LocalSvg.tsx
@@ -1,5 +1,10 @@
 import React, { useState, useEffect, Component } from 'react';
-import { NativeModules, Platform, Image, ImageSourcePropType } from 'react-native';
+import {
+  NativeModules,
+  Platform,
+  Image,
+  ImageSourcePropType,
+} from 'react-native';
 
 import { fetchText } from './xml';
 import { SvgCss, SvgWithCss } from './css';


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

PR adding proper typings for `asset` prop of `LocalSvg` based on `Image.resolveAssetSource()` typings. Based on #1593 by @pratyushok. Should fix #1537.