### PR TITLE
feat: fix broken enum declaration

### DIFF
--- a/src/elements/Marker.tsx
+++ b/src/elements/Marker.tsx
@@ -4,15 +4,9 @@ import { NumberProp } from '../lib/extract/types';
 import Shape from './Shape';
 import { RNSVGMarker } from './NativeComponents';
 
-export enum MarkerUnits {
-  STROKE_WIDTH = 'strokeWidth',
-  USER_SPACE_ON_USE = 'userSpaceOnUse',
-}
+export type MarkerUnits = 'strokeWidth' | 'userSpaceOnUse';
 
-export enum Orient {
-  AUTO = 'auto',
-  AUTO_START_REVERSE = 'auto-start-reverse',
-}
+export type Orient = 'auto' | 'auto-start-reverse';
 
 export interface MarkerProps {
   children?: ReactNode;

--- a/src/elements/Mask.tsx
+++ b/src/elements/Mask.tsx
@@ -10,14 +10,7 @@ import units from '../lib/units';
 import Shape from './Shape';
 import { RNSVGMask } from './NativeComponents';
 
-export enum EMaskUnits {
-  USER_SPACE_ON_USE = 'userSpaceOnUse',
-  OBJECT_BOUNDING_BOX = 'objectBoundingBox',
-}
-
-export type TMaskUnits =
-  | EMaskUnits.USER_SPACE_ON_USE
-  | EMaskUnits.OBJECT_BOUNDING_BOX;
+export type TMaskUnits = 'userSpaceOnUse' | 'objectBoundingBox';
 
 export interface MaskProps extends CommonPathProps {
   children?: ReactNode;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
Fixes #1210 again

This PR is rewrite version of #1800 refactored with 286c02fac46ab5ac65f67a3ae2b99d3f1d37a18c

After #1800 merged, the refactoring 286c02fac46ab5ac65f67a3ae2b99d3f1d37a18c was performed and enum declaration was back to previous one.
So type error mentioned at #1210 for maskUnits should occurred again.

Wouldn't you better to refactor the enum like this PR?

## Test Plan
This PR doesn't affect any executable code.
Only change type declaration

### What's required for testing (prerequisites)?
None

### What are the steps to reproduce (after prerequisites)?
None

## Compatibility
Only changes the Typescript declaration

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
