### PR TITLE
Fix constructor with deprecated context

### DIFF
--- a/src/elements/Shape.tsx
+++ b/src/elements/Shape.tsx
@@ -230,8 +230,8 @@ export const ownerSVGElement = {
 export default class Shape<P> extends Component<P> {
   [x: string]: unknown;
   root: (Shape<P> & NativeMethods) | null = null;
-  constructor(props: P, context: {}) {
-    super(props, context);
+  constructor(props: Readonly<P> | P) {
+    super(props);
     SvgTouchableMixin(this);
   }
   refMethod: (instance: (Shape<P> & NativeMethods) | null) => void = (


### PR DESCRIPTION
# Summary

The constructor with context is deprecated and occurs types error in `react-native@69+`.
See https://reactjs.org/docs/legacy-context.html

## Test Plan

With react-native 0.69+ project try below.

```
const AnimCircle = Animated.createAnimatedComponent(Circle);
```
then the error occurs.
<img width="600" alt="Screen Shot 2022-08-03 at 2 14 13 PM" src="https://user-images.githubusercontent.com/27461460/182529273-9af3ee76-cdda-4980-8df6-9358e0b1b106.png">

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added documentation in `README.md`
- [x] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
