### PR TITLE
Add support for translateX and translateY on web

### DIFF
--- a/src/ReactNativeSVG.web.ts
+++ b/src/ReactNativeSVG.web.ts
@@ -45,6 +45,8 @@ interface BaseProps {
   rejectResponderTermination?: boolean;
 
   translate: NumberArray;
+  translateX: NumberProp;
+  translateY: NumberProp;
   scale: NumberArray;
   rotation: NumberArray;
   skewX: NumberProp;
@@ -78,6 +80,8 @@ const prepare = <T extends BaseProps>(
 ) => {
   const {
     translate,
+    translateX,
+    translateY,
     scale,
     rotation,
     skewX,
@@ -127,6 +131,9 @@ const prepare = <T extends BaseProps>(
   }
   if (translate != null) {
     transform.push(`translate(${translate})`);
+  }
+  if (translateX != null || translateY != null) {
+    transform.push(`translate(${translateX || 0}, ${translateY || 0})`);
   }
   if (scale != null) {
     transform.push(`scale(${scale})`);


### PR DESCRIPTION
# Summary

This PR is fixing part of issue https://github.com/react-native-svg/react-native-svg/issues/1824
Props _translateX_ and _translateY_ are ignored on web. This PR is addressing it the same way as it is already done for _originX_ and _originY_.

This PR is not addressing the issue of _transform_ as stated in issue.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    tested     |
| Android |    not affecting     |
| Web |    ✅     |

## Checklist

- [X] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [X] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
