### PR TITLE
fix: export types from lib which were available before

### DIFF
--- a/src/ReactNativeSVG.ts
+++ b/src/ReactNativeSVG.ts
@@ -102,6 +102,8 @@ export {
   LocalProps,
 };
 
+export * from './lib/extract/types';
+
 export {
   Svg,
   Circle,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Exported all types from `lib/extract/types.tsx` since most of them were available before refactor done in #1806.
