### PR TITLE
chore: revert android ci cache

### DIFF
--- a/.github/workflows/android-build-test.yml
+++ b/.github/workflows/android-build-test.yml
@@ -22,7 +22,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
 
       - name: Set up JDK 11
         uses: actions/setup-java@v1
@@ -45,7 +45,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Restore app node_modules from cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache-node-modules-app
         with:
           path: |

--- a/.github/workflows/android-build-test.yml
+++ b/.github/workflows/android-build-test.yml
@@ -22,7 +22,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up JDK 11
         uses: actions/setup-java@v1
@@ -57,24 +57,6 @@ jobs:
         working-directory: ${{ matrix.working-directory }}
         run: yarn install --frozen-lockfile
 
-      - name: Restore build from cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-            android/build
-            android/.cxx
-            ${{ matrix.working-directory }}/android/build
-            ${{ matrix.working-directory }}/android/.cxx
-            ${{ matrix.working-directory }}/android/.gradle
-            ${{ matrix.working-directory }}/android/app/build
-            ${{ matrix.working-directory }}/android/app/.cxx
-            ${{ matrix.working-directory }}/node_modules/react-native/ReactAndroid/build
-            ${{ matrix.working-directory }}/node_modules/react-native/ReactAndroid/hermes-engine/build
-            ${{ matrix.working-directory }}/node_modules/react-native/ReactAndroid/hermes-engine/.cxx
-          key: ${{ runner.os }}-build5-${{ matrix.working-directory }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', 'android/build.gradle', format('{0}/node_modules/react-native/sdks/.hermesversion', matrix.working-directory)) }}
-
       - name: Build app
-        working-directory: ${{ matrix.working-directory }}/android
-        run: ./gradlew assembleDebug --build-cache --console=plain -PreactNativeArchitectures=arm64-v8a
+        working-directory: ${{ env.WORKING_DIRECTORY }}/android
+        run: ./gradlew assembleDebug --console=plain

--- a/.github/workflows/android-build-test.yml
+++ b/.github/workflows/android-build-test.yml
@@ -33,7 +33,7 @@ jobs:
         run: /bin/bash -c "yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses > /dev/null"
 
       - name: Restore svg node_modules from cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache-node-modules-svg
         with:
           path: |
@@ -58,5 +58,5 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Build app
-        working-directory: ${{ env.WORKING_DIRECTORY }}/android
-        run: ./gradlew assembleDebug --console=plain
+        working-directory: ${{ matrix.working-directory }}/android
+        run: ./gradlew assembleDebug --console=plain -PreactNativeArchitectures=arm64-v8a

--- a/.github/workflows/ios-build-test.yml
+++ b/.github/workflows/ios-build-test.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Restore svg node_modules from cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache-node-modules-svg
         with:
           path: |
@@ -38,7 +38,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Restore app node_modules from cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache-node-modules-app
         with:
           path: |
@@ -51,7 +51,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Restore Pods from cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache-pods
         with:
           path: |
@@ -65,7 +65,7 @@ jobs:
         run: pod install
 
       - name: Restore build artifacts from cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache-build
         with:
           path: |

--- a/.github/workflows/macos-build-test.yml
+++ b/.github/workflows/macos-build-test.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Restore svg node_modules from cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache-node-modules-svg
         with:
           path: |
@@ -36,7 +36,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Restore app node_modules from cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache-node-modules-app
         with:
           path: |
@@ -49,7 +49,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Restore Pods from cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache-pods
         with:
           path: |
@@ -64,7 +64,7 @@ jobs:
         run: pod install
 
       - name: Restore build artifacts from cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache-build
         with:
           path: |


### PR DESCRIPTION
Changed CI jobs reverting not working Android cache and adding `cache@v3` to jobs.