### PR TITLE
fix: make svg invalidate after props update

### DIFF
--- a/FabricExample/ios/Podfile.lock
+++ b/FabricExample/ios/Podfile.lock
@@ -697,7 +697,7 @@ PODS:
     - React-jsi (= 0.70.0-rc.3)
     - React-logger (= 0.70.0-rc.3)
     - React-perflogger (= 0.70.0-rc.3)
-  - RNSVG (12.4.4):
+  - RNSVG (13.0.0):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -927,7 +927,7 @@ SPEC CHECKSUMS:
   React-rncore: 55e35fbadf994c9efa605a78bf9d1fb3f080bc55
   React-runtimeexecutor: 538c4d995c729b5247ac3149774f0a53f98570dd
   ReactCommon: f7fc6b8b10e8f16f65a8009be266cfc1478fb20d
-  RNSVG: 7b29007eb3f0c22975ee09c5cfab0459b1d78560
+  RNSVG: dcd4ba8276e49a34fac0d57ea25bdddde1b7d247
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
   Yoga: 65fe91a246110ebd54e9c7388d98e90d861cb4e7
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a

--- a/android/src/main/java/com/horcrux/svg/RenderableViewManager.java
+++ b/android/src/main/java/com/horcrux/svg/RenderableViewManager.java
@@ -542,9 +542,10 @@ class VirtualViewManager<V extends VirtualView> extends ViewGroupManager<Virtual
    * you want to override this method you should call super.onAfterUpdateTransaction from it as the
    * parent class of the ViewManager may rely on callback being executed.
    */
-  protected void onAfterUpdateTransaction(@Nonnull V node) {
+  @Override
+  protected void onAfterUpdateTransaction(@Nonnull VirtualView node) {
     super.onAfterUpdateTransaction(node);
-    invalidateSvgView(node);
+    invalidateSvgView((V) node);
   }
 
   protected enum SVGClass {


### PR DESCRIPTION
Previous method definition resulted in not overriding the base method so after the props update, `SvgView` was not invalidated and redrawn. Should fix #1840.