### PR TITLE
fix: bitmap nulled before screen transition

### DIFF
--- a/android/src/main/java/com/horcrux/svg/RenderableViewManager.java
+++ b/android/src/main/java/com/horcrux/svg/RenderableViewManager.java
@@ -530,6 +530,10 @@ class VirtualViewManager<V extends VirtualView> extends ViewGroupManager<Virtual
           @Override
           public void onChildViewRemoved(View view, View view1) {
             if (view instanceof VirtualView) {
+              SvgView svgView = ((VirtualView) view).getSvgView();
+              if (svgView != null) {
+                svgView.setRemovedFromReactViewHierarchy();
+              }
               invalidateSvgView((V) view);
             }
           }
@@ -542,9 +546,10 @@ class VirtualViewManager<V extends VirtualView> extends ViewGroupManager<Virtual
    * you want to override this method you should call super.onAfterUpdateTransaction from it as the
    * parent class of the ViewManager may rely on callback being executed.
    */
-  protected void onAfterUpdateTransaction(@Nonnull V node) {
+  @Override
+  protected void onAfterUpdateTransaction(@Nonnull VirtualView node) {
     super.onAfterUpdateTransaction(node);
-    invalidateSvgView(node);
+    invalidateSvgView((V) node);
   }
 
   protected enum SVGClass {

--- a/android/src/main/java/com/horcrux/svg/SvgView.java
+++ b/android/src/main/java/com/horcrux/svg/SvgView.java
@@ -59,6 +59,7 @@ public class SvgView extends FabricEnabledViewGroup
   }
 
   private @Nullable Bitmap mBitmap;
+  private boolean mRemovedFromReactViewHierarchy;
 
   public SvgView(ReactContext reactContext) {
     super(reactContext);
@@ -73,6 +74,10 @@ public class SvgView extends FabricEnabledViewGroup
     SvgViewManager.setSvgView(id, this);
   }
 
+  public void setRemovedFromReactViewHierarchy() {
+    mRemovedFromReactViewHierarchy = true;
+  }
+
   @Override
   public void invalidate() {
     super.invalidate();
@@ -85,6 +90,20 @@ public class SvgView extends FabricEnabledViewGroup
       ((VirtualView) parent).getSvgView().invalidate();
       return;
     }
+    if (!mRemovedFromReactViewHierarchy) {
+      // when view is removed from the view hierarchy, we want to recycle the mBitmap when
+      // the view is detached from window, in order to preserve it for during animation, see
+      // https://github.com/react-native-svg/react-native-svg/pull/1542
+      if (mBitmap != null) {
+        mBitmap.recycle();
+      }
+      mBitmap = null;
+    }
+  }
+
+  @Override
+  protected void onDetachedFromWindow() {
+    super.onDetachedFromWindow();
     if (mBitmap != null) {
       mBitmap.recycle();
     }


### PR DESCRIPTION
Duplication of #1542 on the newest main with a null check on `svgView`.