### PR TITLE
fix: setters for old react native versions

### DIFF
--- a/android/src/main/java/com/horcrux/svg/RenderableView.java
+++ b/android/src/main/java/com/horcrux/svg/RenderableView.java
@@ -119,6 +119,7 @@ public abstract class RenderableView extends VirtualView {
     if (fillType.equals(ReadableType.Map)) {
       ReadableMap fillMap = fill.asMap();
       setFill(fillMap);
+      return;
     }
 
     // This code will probably never be reached with current changes
@@ -190,6 +191,15 @@ public abstract class RenderableView extends VirtualView {
       invalidate();
       return;
     }
+
+    ReadableType strokeType = strokeColors.getType();
+    if (strokeType.equals(ReadableType.Map)) {
+      ReadableMap strokeMap = strokeColors.asMap();
+      setStroke(strokeMap);
+      return;
+    }
+
+    // This code will probably never be reached with current changes
     ReadableType type = strokeColors.getType();
     if (type.equals(ReadableType.Number)) {
       stroke = JavaOnlyArray.of(0, strokeColors.asInt());

--- a/android/src/main/java/com/horcrux/svg/VirtualView.java
+++ b/android/src/main/java/com/horcrux/svg/VirtualView.java
@@ -305,7 +305,8 @@ public abstract class VirtualView extends ReactViewGroup {
   public void setMatrix(Dynamic matrixArray) {
     ReadableType type = matrixArray.getType();
     if (!matrixArray.isNull() && type.equals(ReadableType.Array)) {
-      setMatrix((ReadableArray) matrixArray);
+      ReadableArray matrix = matrixArray.asArray();
+      setMatrix(matrix);
     } else {
       mMatrix.reset();
       mInvMatrix.reset();


### PR DESCRIPTION
On old `react-native` versions (e.g. 0.64.4), property setters on Android were handled differently, which resulted in calling `Dynamic` setters for e.g. `fill`, `matrix` and `stroke` prop. Since `JS` code has been changed, the props on the native side look a bit different. It lead to bugs in mentioned props, which was not spotted since the code was tested only on the newer versions of `react-native`, where new view managers are used and props do not resolve in `Dynamic` setters.