### PR TITLE
Use angle-bracket imports

### DIFF
--- a/apple/Elements/RNSVGClipPath.mm
+++ b/apple/Elements/RNSVGClipPath.mm
@@ -9,10 +9,10 @@
 #import "RNSVGClipPath.h"
 
 #ifdef RN_FABRIC_ENABLED
-#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
-#import <react/renderer/components/view/conversions.h>
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
+#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
+#import <react/renderer/components/view/conversions.h>
 #import "RNSVGFabricConversions.h"
 #endif // RN_FABRIC_ENABLED
 

--- a/apple/Elements/RNSVGClipPath.mm
+++ b/apple/Elements/RNSVGClipPath.mm
@@ -11,8 +11,8 @@
 #ifdef RN_FABRIC_ENABLED
 #import <react/renderer/components/rnsvg/ComponentDescriptors.h>
 #import <react/renderer/components/view/conversions.h>
-#import "RCTConversions.h"
-#import "RCTFabricComponentsPlugins.h"
+#import <React/RCTConversions.h>
+#import <React/RCTFabricComponentsPlugins.h>
 #import "RNSVGFabricConversions.h"
 #endif // RN_FABRIC_ENABLED
 

--- a/apple/Elements/RNSVGDefs.mm
+++ b/apple/Elements/RNSVGDefs.mm
@@ -8,10 +8,10 @@
 #import "RNSVGDefs.h"
 
 #ifdef RN_FABRIC_ENABLED
-#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
-#import <react/renderer/components/view/conversions.h>
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
+#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
+#import <react/renderer/components/view/conversions.h>
 #import "RNSVGFabricConversions.h"
 #endif // RN_FABRIC_ENABLED
 

--- a/apple/Elements/RNSVGDefs.mm
+++ b/apple/Elements/RNSVGDefs.mm
@@ -10,8 +10,8 @@
 #ifdef RN_FABRIC_ENABLED
 #import <react/renderer/components/rnsvg/ComponentDescriptors.h>
 #import <react/renderer/components/view/conversions.h>
-#import "RCTConversions.h"
-#import "RCTFabricComponentsPlugins.h"
+#import <React/RCTConversions.h>
+#import <React/RCTFabricComponentsPlugins.h>
 #import "RNSVGFabricConversions.h"
 #endif // RN_FABRIC_ENABLED
 

--- a/apple/Elements/RNSVGForeignObject.mm
+++ b/apple/Elements/RNSVGForeignObject.mm
@@ -11,10 +11,10 @@
 #import "RNSVGNode.h"
 
 #ifdef RN_FABRIC_ENABLED
-#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
-#import <react/renderer/components/view/conversions.h>
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
+#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
+#import <react/renderer/components/view/conversions.h>
 #import "RNSVGFabricConversions.h"
 #endif // RN_FABRIC_ENABLED
 

--- a/apple/Elements/RNSVGForeignObject.mm
+++ b/apple/Elements/RNSVGForeignObject.mm
@@ -13,8 +13,8 @@
 #ifdef RN_FABRIC_ENABLED
 #import <react/renderer/components/rnsvg/ComponentDescriptors.h>
 #import <react/renderer/components/view/conversions.h>
-#import "RCTConversions.h"
-#import "RCTFabricComponentsPlugins.h"
+#import <React/RCTConversions.h>
+#import <React/RCTFabricComponentsPlugins.h>
 #import "RNSVGFabricConversions.h"
 #endif // RN_FABRIC_ENABLED
 

--- a/apple/Elements/RNSVGGroup.mm
+++ b/apple/Elements/RNSVGGroup.mm
@@ -11,10 +11,10 @@
 #import "RNSVGMask.h"
 
 #ifdef RN_FABRIC_ENABLED
-#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
-#import <react/renderer/components/view/conversions.h>
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
+#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
+#import <react/renderer/components/view/conversions.h>
 #import "RNSVGFabricConversions.h"
 #endif // RN_FABRIC_ENABLED
 

--- a/apple/Elements/RNSVGGroup.mm
+++ b/apple/Elements/RNSVGGroup.mm
@@ -13,8 +13,8 @@
 #ifdef RN_FABRIC_ENABLED
 #import <react/renderer/components/rnsvg/ComponentDescriptors.h>
 #import <react/renderer/components/view/conversions.h>
-#import "RCTConversions.h"
-#import "RCTFabricComponentsPlugins.h"
+#import <React/RCTConversions.h>
+#import <React/RCTFabricComponentsPlugins.h>
 #import "RNSVGFabricConversions.h"
 #endif // RN_FABRIC_ENABLED
 

--- a/apple/Elements/RNSVGImage.mm
+++ b/apple/Elements/RNSVGImage.mm
@@ -22,17 +22,17 @@
 
 #endif // RN_FABRIC_ENABLED
 
-#import <React/RCTLog.h>
 #import <React/RCTBridge.h>
+#import <React/RCTLog.h>
 #import "RNSVGViewBox.h"
 
 #ifdef RN_FABRIC_ENABLED
-#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
-#import <react/renderer/components/view/conversions.h>
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
-#import <React/RCTImagePrimitivesConversions.h>
 #import <React/RCTImageSource.h>
+#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
+#import <react/renderer/components/view/conversions.h>
+#import <react/renderer/imagemanager/RCTImagePrimitivesConversions.h>
 #import "RNSVGFabricConversions.h"
 
 // Some RN private method hacking below similar to how it is done in RNScreens:

--- a/apple/Elements/RNSVGImage.mm
+++ b/apple/Elements/RNSVGImage.mm
@@ -23,16 +23,16 @@
 #endif // RN_FABRIC_ENABLED
 
 #import <React/RCTLog.h>
-#import "RCTBridge.h"
+#import <React/RCTBridge.h>
 #import "RNSVGViewBox.h"
 
 #ifdef RN_FABRIC_ENABLED
 #import <react/renderer/components/rnsvg/ComponentDescriptors.h>
 #import <react/renderer/components/view/conversions.h>
-#import "RCTConversions.h"
-#import "RCTFabricComponentsPlugins.h"
-#import "RCTImagePrimitivesConversions.h"
-#import "RCTImageSource.h"
+#import <React/RCTConversions.h>
+#import <React/RCTFabricComponentsPlugins.h>
+#import <React/RCTImagePrimitivesConversions.h>
+#import <React/RCTImageSource.h>
 #import "RNSVGFabricConversions.h"
 
 // Some RN private method hacking below similar to how it is done in RNScreens:

--- a/apple/Elements/RNSVGLinearGradient.mm
+++ b/apple/Elements/RNSVGLinearGradient.mm
@@ -10,10 +10,10 @@
 #import "RNSVGPainter.h"
 
 #ifdef RN_FABRIC_ENABLED
-#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
-#import <react/renderer/components/view/conversions.h>
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
+#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
+#import <react/renderer/components/view/conversions.h>
 #import "RNSVGFabricConversions.h"
 #endif // RN_FABRIC_ENABLED
 

--- a/apple/Elements/RNSVGLinearGradient.mm
+++ b/apple/Elements/RNSVGLinearGradient.mm
@@ -12,8 +12,8 @@
 #ifdef RN_FABRIC_ENABLED
 #import <react/renderer/components/rnsvg/ComponentDescriptors.h>
 #import <react/renderer/components/view/conversions.h>
-#import "RCTConversions.h"
-#import "RCTFabricComponentsPlugins.h"
+#import <React/RCTConversions.h>
+#import <React/RCTFabricComponentsPlugins.h>
 #import "RNSVGFabricConversions.h"
 #endif // RN_FABRIC_ENABLED
 

--- a/apple/Elements/RNSVGMarker.mm
+++ b/apple/Elements/RNSVGMarker.mm
@@ -14,8 +14,8 @@
 #ifdef RN_FABRIC_ENABLED
 #import <react/renderer/components/rnsvg/ComponentDescriptors.h>
 #import <react/renderer/components/view/conversions.h>
-#import "RCTConversions.h"
-#import "RCTFabricComponentsPlugins.h"
+#import <React/RCTConversions.h>
+#import <React/RCTFabricComponentsPlugins.h>
 #import "RNSVGFabricConversions.h"
 #endif // RN_FABRIC_ENABLED
 

--- a/apple/Elements/RNSVGMarker.mm
+++ b/apple/Elements/RNSVGMarker.mm
@@ -12,10 +12,10 @@
 #import "RNSVGViewBox.h"
 
 #ifdef RN_FABRIC_ENABLED
-#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
-#import <react/renderer/components/view/conversions.h>
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
+#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
+#import <react/renderer/components/view/conversions.h>
 #import "RNSVGFabricConversions.h"
 #endif // RN_FABRIC_ENABLED
 

--- a/apple/Elements/RNSVGMask.mm
+++ b/apple/Elements/RNSVGMask.mm
@@ -11,10 +11,10 @@
 #import "RNSVGPainter.h"
 
 #ifdef RN_FABRIC_ENABLED
-#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
-#import <react/renderer/components/view/conversions.h>
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
+#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
+#import <react/renderer/components/view/conversions.h>
 #import "RNSVGFabricConversions.h"
 #endif // RN_FABRIC_ENABLED
 

--- a/apple/Elements/RNSVGMask.mm
+++ b/apple/Elements/RNSVGMask.mm
@@ -13,8 +13,8 @@
 #ifdef RN_FABRIC_ENABLED
 #import <react/renderer/components/rnsvg/ComponentDescriptors.h>
 #import <react/renderer/components/view/conversions.h>
-#import "RCTConversions.h"
-#import "RCTFabricComponentsPlugins.h"
+#import <React/RCTConversions.h>
+#import <React/RCTFabricComponentsPlugins.h>
 #import "RNSVGFabricConversions.h"
 #endif // RN_FABRIC_ENABLED
 

--- a/apple/Elements/RNSVGPath.mm
+++ b/apple/Elements/RNSVGPath.mm
@@ -11,8 +11,8 @@
 #ifdef RN_FABRIC_ENABLED
 #import <react/renderer/components/rnsvg/ComponentDescriptors.h>
 #import <react/renderer/components/view/conversions.h>
-#import "RCTConversions.h"
-#import "RCTFabricComponentsPlugins.h"
+#import <React/RCTConversions.h>
+#import <React/RCTFabricComponentsPlugins.h>
 #import "RNSVGFabricConversions.h"
 #endif // RN_FABRIC_ENABLED
 

--- a/apple/Elements/RNSVGPath.mm
+++ b/apple/Elements/RNSVGPath.mm
@@ -9,10 +9,10 @@
 #import "RNSVGPath.h"
 
 #ifdef RN_FABRIC_ENABLED
-#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
-#import <react/renderer/components/view/conversions.h>
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
+#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
+#import <react/renderer/components/view/conversions.h>
 #import "RNSVGFabricConversions.h"
 #endif // RN_FABRIC_ENABLED
 

--- a/apple/Elements/RNSVGPattern.mm
+++ b/apple/Elements/RNSVGPattern.mm
@@ -11,10 +11,10 @@
 #import "RNSVGPainter.h"
 
 #ifdef RN_FABRIC_ENABLED
-#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
-#import <react/renderer/components/view/conversions.h>
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
+#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
+#import <react/renderer/components/view/conversions.h>
 #import "RNSVGFabricConversions.h"
 #endif // RN_FABRIC_ENABLED
 

--- a/apple/Elements/RNSVGPattern.mm
+++ b/apple/Elements/RNSVGPattern.mm
@@ -13,8 +13,8 @@
 #ifdef RN_FABRIC_ENABLED
 #import <react/renderer/components/rnsvg/ComponentDescriptors.h>
 #import <react/renderer/components/view/conversions.h>
-#import "RCTConversions.h"
-#import "RCTFabricComponentsPlugins.h"
+#import <React/RCTConversions.h>
+#import <React/RCTFabricComponentsPlugins.h>
 #import "RNSVGFabricConversions.h"
 #endif // RN_FABRIC_ENABLED
 

--- a/apple/Elements/RNSVGRadialGradient.mm
+++ b/apple/Elements/RNSVGRadialGradient.mm
@@ -8,10 +8,10 @@
 #import "RNSVGRadialGradient.h"
 
 #ifdef RN_FABRIC_ENABLED
-#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
-#import <react/renderer/components/view/conversions.h>
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
+#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
+#import <react/renderer/components/view/conversions.h>
 #import "RNSVGFabricConversions.h"
 #endif // RN_FABRIC_ENABLED
 

--- a/apple/Elements/RNSVGRadialGradient.mm
+++ b/apple/Elements/RNSVGRadialGradient.mm
@@ -10,8 +10,8 @@
 #ifdef RN_FABRIC_ENABLED
 #import <react/renderer/components/rnsvg/ComponentDescriptors.h>
 #import <react/renderer/components/view/conversions.h>
-#import "RCTConversions.h"
-#import "RCTFabricComponentsPlugins.h"
+#import <React/RCTConversions.h>
+#import <React/RCTFabricComponentsPlugins.h>
 #import "RNSVGFabricConversions.h"
 #endif // RN_FABRIC_ENABLED
 

--- a/apple/Elements/RNSVGSvgView.mm
+++ b/apple/Elements/RNSVGSvgView.mm
@@ -14,8 +14,8 @@
 #ifdef RN_FABRIC_ENABLED
 #import <react/renderer/components/rnsvg/ComponentDescriptors.h>
 #import <react/renderer/components/view/conversions.h>
-#import "RCTConversions.h"
-#import "RCTFabricComponentsPlugins.h"
+#import <React/RCTConversions.h>
+#import <React/RCTFabricComponentsPlugins.h>
 #import "RNSVGFabricConversions.h"
 #endif // RN_FABRIC_ENABLED
 

--- a/apple/Elements/RNSVGSvgView.mm
+++ b/apple/Elements/RNSVGSvgView.mm
@@ -12,10 +12,10 @@
 #import "RNSVGViewBox.h"
 
 #ifdef RN_FABRIC_ENABLED
-#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
-#import <react/renderer/components/view/conversions.h>
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
+#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
+#import <react/renderer/components/view/conversions.h>
 #import "RNSVGFabricConversions.h"
 #endif // RN_FABRIC_ENABLED
 

--- a/apple/Elements/RNSVGSymbol.mm
+++ b/apple/Elements/RNSVGSymbol.mm
@@ -9,10 +9,10 @@
 #import "RNSVGViewBox.h"
 
 #ifdef RN_FABRIC_ENABLED
-#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
-#import <react/renderer/components/view/conversions.h>
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
+#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
+#import <react/renderer/components/view/conversions.h>
 #import "RNSVGFabricConversions.h"
 #endif // RN_FABRIC_ENABLED
 

--- a/apple/Elements/RNSVGSymbol.mm
+++ b/apple/Elements/RNSVGSymbol.mm
@@ -11,8 +11,8 @@
 #ifdef RN_FABRIC_ENABLED
 #import <react/renderer/components/rnsvg/ComponentDescriptors.h>
 #import <react/renderer/components/view/conversions.h>
-#import "RCTConversions.h"
-#import "RCTFabricComponentsPlugins.h"
+#import <React/RCTConversions.h>
+#import <React/RCTFabricComponentsPlugins.h>
 #import "RNSVGFabricConversions.h"
 #endif // RN_FABRIC_ENABLED
 

--- a/apple/Elements/RNSVGUse.mm
+++ b/apple/Elements/RNSVGUse.mm
@@ -10,10 +10,10 @@
 #import "RNSVGSymbol.h"
 
 #ifdef RN_FABRIC_ENABLED
-#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
-#import <react/renderer/components/view/conversions.h>
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
+#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
+#import <react/renderer/components/view/conversions.h>
 #import "RNSVGFabricConversions.h"
 #endif // RN_FABRIC_ENABLED
 

--- a/apple/Elements/RNSVGUse.mm
+++ b/apple/Elements/RNSVGUse.mm
@@ -12,8 +12,8 @@
 #ifdef RN_FABRIC_ENABLED
 #import <react/renderer/components/rnsvg/ComponentDescriptors.h>
 #import <react/renderer/components/view/conversions.h>
-#import "RCTConversions.h"
-#import "RCTFabricComponentsPlugins.h"
+#import <React/RCTConversions.h>
+#import <React/RCTFabricComponentsPlugins.h>
 #import "RNSVGFabricConversions.h"
 #endif // RN_FABRIC_ENABLED
 

--- a/apple/Shapes/RNSVGCircle.mm
+++ b/apple/Shapes/RNSVGCircle.mm
@@ -12,8 +12,8 @@
 #ifdef RN_FABRIC_ENABLED
 #import <react/renderer/components/rnsvg/ComponentDescriptors.h>
 #import <react/renderer/components/view/conversions.h>
-#import "RCTConversions.h"
-#import "RCTFabricComponentsPlugins.h"
+#import <React/RCTConversions.h>
+#import <React/RCTFabricComponentsPlugins.h>
 #import "RNSVGFabricConversions.h"
 #endif // RN_FABRIC_ENABLED
 

--- a/apple/Shapes/RNSVGCircle.mm
+++ b/apple/Shapes/RNSVGCircle.mm
@@ -10,10 +10,10 @@
 #import <React/RCTLog.h>
 
 #ifdef RN_FABRIC_ENABLED
-#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
-#import <react/renderer/components/view/conversions.h>
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
+#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
+#import <react/renderer/components/view/conversions.h>
 #import "RNSVGFabricConversions.h"
 #endif // RN_FABRIC_ENABLED
 

--- a/apple/Shapes/RNSVGEllipse.mm
+++ b/apple/Shapes/RNSVGEllipse.mm
@@ -12,8 +12,8 @@
 #ifdef RN_FABRIC_ENABLED
 #import <react/renderer/components/rnsvg/ComponentDescriptors.h>
 #import <react/renderer/components/view/conversions.h>
-#import "RCTConversions.h"
-#import "RCTFabricComponentsPlugins.h"
+#import <React/RCTConversions.h>
+#import <React/RCTFabricComponentsPlugins.h>
 #import "RNSVGFabricConversions.h"
 #endif // RN_FABRIC_ENABLED
 

--- a/apple/Shapes/RNSVGEllipse.mm
+++ b/apple/Shapes/RNSVGEllipse.mm
@@ -10,10 +10,10 @@
 #import <React/RCTLog.h>
 
 #ifdef RN_FABRIC_ENABLED
-#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
-#import <react/renderer/components/view/conversions.h>
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
+#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
+#import <react/renderer/components/view/conversions.h>
 #import "RNSVGFabricConversions.h"
 #endif // RN_FABRIC_ENABLED
 

--- a/apple/Shapes/RNSVGLine.mm
+++ b/apple/Shapes/RNSVGLine.mm
@@ -12,8 +12,8 @@
 #ifdef RN_FABRIC_ENABLED
 #import <react/renderer/components/rnsvg/ComponentDescriptors.h>
 #import <react/renderer/components/view/conversions.h>
-#import "RCTConversions.h"
-#import "RCTFabricComponentsPlugins.h"
+#import <React/RCTConversions.h>
+#import <React/RCTFabricComponentsPlugins.h>
 #import "RNSVGFabricConversions.h"
 #endif // RN_FABRIC_ENABLED
 

--- a/apple/Shapes/RNSVGLine.mm
+++ b/apple/Shapes/RNSVGLine.mm
@@ -10,10 +10,10 @@
 #import <React/RCTLog.h>
 
 #ifdef RN_FABRIC_ENABLED
-#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
-#import <react/renderer/components/view/conversions.h>
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
+#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
+#import <react/renderer/components/view/conversions.h>
 #import "RNSVGFabricConversions.h"
 #endif // RN_FABRIC_ENABLED
 

--- a/apple/Shapes/RNSVGRect.mm
+++ b/apple/Shapes/RNSVGRect.mm
@@ -12,8 +12,8 @@
 #ifdef RN_FABRIC_ENABLED
 #import <react/renderer/components/rnsvg/ComponentDescriptors.h>
 #import <react/renderer/components/view/conversions.h>
-#import "RCTConversions.h"
-#import "RCTFabricComponentsPlugins.h"
+#import <React/RCTConversions.h>
+#import <React/RCTFabricComponentsPlugins.h>
 #import "RNSVGFabricConversions.h"
 #endif // RN_FABRIC_ENABLED
 

--- a/apple/Shapes/RNSVGRect.mm
+++ b/apple/Shapes/RNSVGRect.mm
@@ -10,10 +10,10 @@
 #import <React/RCTLog.h>
 
 #ifdef RN_FABRIC_ENABLED
-#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
-#import <react/renderer/components/view/conversions.h>
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
+#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
+#import <react/renderer/components/view/conversions.h>
 #import "RNSVGFabricConversions.h"
 #endif // RN_FABRIC_ENABLED
 

--- a/apple/Text/RNSVGTSpan.mm
+++ b/apple/Text/RNSVGTSpan.mm
@@ -20,8 +20,8 @@ static CGFloat RNSVGTSpan_radToDeg = 180 / (CGFloat)M_PI;
 #ifdef RN_FABRIC_ENABLED
 #import <react/renderer/components/rnsvg/ComponentDescriptors.h>
 #import <react/renderer/components/view/conversions.h>
-#import "RCTConversions.h"
-#import "RCTFabricComponentsPlugins.h"
+#import <React/RCTConversions.h>
+#import <React/RCTFabricComponentsPlugins.h>
 #import "RNSVGFabricConversions.h"
 #endif // RN_FABRIC_ENABLED
 

--- a/apple/Text/RNSVGTSpan.mm
+++ b/apple/Text/RNSVGTSpan.mm
@@ -18,10 +18,10 @@ static NSCharacterSet *RNSVGTSpan_separators = nil;
 static CGFloat RNSVGTSpan_radToDeg = 180 / (CGFloat)M_PI;
 
 #ifdef RN_FABRIC_ENABLED
-#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
-#import <react/renderer/components/view/conversions.h>
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
+#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
+#import <react/renderer/components/view/conversions.h>
 #import "RNSVGFabricConversions.h"
 #endif // RN_FABRIC_ENABLED
 

--- a/apple/Text/RNSVGText.mm
+++ b/apple/Text/RNSVGText.mm
@@ -16,8 +16,8 @@
 #ifdef RN_FABRIC_ENABLED
 #import <react/renderer/components/rnsvg/ComponentDescriptors.h>
 #import <react/renderer/components/view/conversions.h>
-#import "RCTConversions.h"
-#import "RCTFabricComponentsPlugins.h"
+#import <React/RCTConversions.h>
+#import <React/RCTFabricComponentsPlugins.h>
 #import "RNSVGFabricConversions.h"
 #endif // RN_FABRIC_ENABLED
 

--- a/apple/Text/RNSVGText.mm
+++ b/apple/Text/RNSVGText.mm
@@ -14,10 +14,10 @@
 #import "RNSVGTextProperties.h"
 
 #ifdef RN_FABRIC_ENABLED
-#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
-#import <react/renderer/components/view/conversions.h>
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
+#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
+#import <react/renderer/components/view/conversions.h>
 #import "RNSVGFabricConversions.h"
 #endif // RN_FABRIC_ENABLED
 

--- a/apple/Text/RNSVGTextPath.mm
+++ b/apple/Text/RNSVGTextPath.mm
@@ -11,8 +11,8 @@
 #ifdef RN_FABRIC_ENABLED
 #import <react/renderer/components/rnsvg/ComponentDescriptors.h>
 #import <react/renderer/components/view/conversions.h>
-#import "RCTConversions.h"
-#import "RCTFabricComponentsPlugins.h"
+#import <React/RCTConversions.h>
+#import <React/RCTFabricComponentsPlugins.h>
 #import "RNSVGFabricConversions.h"
 #endif // RN_FABRIC_ENABLED
 

--- a/apple/Text/RNSVGTextPath.mm
+++ b/apple/Text/RNSVGTextPath.mm
@@ -9,10 +9,10 @@
 #import "RNSVGTextPath.h"
 
 #ifdef RN_FABRIC_ENABLED
-#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
-#import <react/renderer/components/view/conversions.h>
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
+#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
+#import <react/renderer/components/view/conversions.h>
 #import "RNSVGFabricConversions.h"
 #endif // RN_FABRIC_ENABLED
 

--- a/apple/Utils/RNSVGFabricConversions.h
+++ b/apple/Utils/RNSVGFabricConversions.h
@@ -6,8 +6,8 @@
 #import "RNSVGSolidColorBrush.h"
 #import "RNSVGVBMOS.h"
 
-#import "RCTConversions.h"
-#import "RCTFabricComponentsPlugins.h"
+#import <React/RCTConversions.h>
+#import <React/RCTFabricComponentsPlugins.h>
 
 template <typename T>
 RNSVGBrush *brushFromColorStruct(T fillObject)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This PR replaces bad double-quotes imports (which break Swift interop) with good angle-bracket imports.

The forbidden pattern is: `#import "RCT`, except for `#import "RCTConvert+RNSVG.h"` which is okay.

See also:
* https://github.com/software-mansion/react-native-reanimated/pull/3150
* https://github.com/software-mansion/react-native-gesture-handler/pull/2180
* https://github.com/software-mansion/react-native-screens/pull/1572

## Test Plan

Check if Example and FabricExample apps compile successfully.
