### PR TITLE
Fix concurrent CI

### DIFF
--- a/.github/workflows/android-build-test.yml
+++ b/.github/workflows/android-build-test.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         working-directory: [Example, FabricExample]
     concurrency:
-      group: android-${{ github.ref }}
+      group: android-${{ matrix.working-directory }}-${{ github.ref }}
       cancel-in-progress: true
     steps:
       - name: Check out Git repository


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This PR should hopefully fix CI jobs for Example and FabricExample apps being cancelled by using `matrix.working_directory` variable in `concurrency.group` identifier.
