### PR TITLE
fix: restore bitmap recycling on children changes

### DIFF
--- a/android/src/main/java/com/horcrux/svg/RenderableViewManager.java
+++ b/android/src/main/java/com/horcrux/svg/RenderableViewManager.java
@@ -530,10 +530,6 @@ class VirtualViewManager<V extends VirtualView> extends ViewGroupManager<Virtual
           @Override
           public void onChildViewRemoved(View view, View view1) {
             if (view instanceof VirtualView) {
-              SvgView svgView = ((VirtualView) view).getSvgView();
-              if (svgView != null) {
-                svgView.setRemovedFromReactViewHierarchy();
-              }
               invalidateSvgView((V) view);
             }
           }

--- a/android/src/main/java/com/horcrux/svg/SvgView.java
+++ b/android/src/main/java/com/horcrux/svg/SvgView.java
@@ -59,7 +59,7 @@ public class SvgView extends ReactViewGroup implements ReactCompoundView, ReactC
   }
 
   private @Nullable Bitmap mBitmap;
-  private boolean mRemovedFromReactViewHierarchy;
+  private boolean mRemovalTransitionStarted;
 
   public SvgView(ReactContext reactContext) {
     super(reactContext);
@@ -74,10 +74,6 @@ public class SvgView extends ReactViewGroup implements ReactCompoundView, ReactC
     SvgViewManager.setSvgView(id, this);
   }
 
-  public void setRemovedFromReactViewHierarchy() {
-    mRemovedFromReactViewHierarchy = true;
-  }
-
   @Override
   public void invalidate() {
     super.invalidate();
@@ -90,7 +86,7 @@ public class SvgView extends ReactViewGroup implements ReactCompoundView, ReactC
       ((VirtualView) parent).getSvgView().invalidate();
       return;
     }
-    if (!mRemovedFromReactViewHierarchy) {
+    if (!mRemovalTransitionStarted) {
       // when view is removed from the view hierarchy, we want to recycle the mBitmap when
       // the view is detached from window, in order to preserve it for during animation, see
       // https://github.com/react-native-svg/react-native-svg/pull/1542
@@ -99,6 +95,11 @@ public class SvgView extends ReactViewGroup implements ReactCompoundView, ReactC
       }
       mBitmap = null;
     }
+  }
+
+  @Override
+  public void startViewTransition(View view) {
+    mRemovalTransitionStarted = true;
   }
 
   @Override


### PR DESCRIPTION
# Summary

PR fixing the regression introduced in #1844. In that PR we set `mRemovedFromReactViewHierarchy` after one of `SvgView`'s children has been removed, resulting in not being able to update it after one of the components in its hierarchy has been removed. In this PR the behavior has been changed, now we subscribe to `startViewTransition` which should be called only by `react-native-screens` when the screen starts its removal animation. It should still work for old issues as well as the new ones.

Fix originally proposed by @msvargas in https://github.com/software-mansion/react-native-screens/issues/773#issuecomment-770043776.

## Test Plan

https://github.com/software-mansion/react-native-screens/issues/773#issuecomment-769418173
https://github.com/react-native-svg/react-native-svg/issues/1859
https://github.com/react-native-svg/react-native-svg/issues/1861
