### PR TITLE
Fixed RCT_NEW_ARCH_ENABLED in podspec

### DIFF
--- a/RNSVG.podspec
+++ b/RNSVG.podspec
@@ -2,7 +2,7 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
-fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED']
+fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 
 Pod::Spec.new do |s|
   s.name              = 'RNSVG'


### PR DESCRIPTION
RCT_NEW_ARCH_ENABLED seems to be always true (even when its value is '0') without an explicit check