### PR TITLE
feat: make pointer events work on both platforms

### DIFF
--- a/.github/workflows/ios-build-test.yml
+++ b/.github/workflows/ios-build-test.yml
@@ -63,6 +63,11 @@ jobs:
         working-directory: ${{ matrix.working-directory }}/ios
         run: pod install
 
+      - name: Generate output of codegen
+        uses: actions/upload-artifact@v3
+        with:
+          path: ${{ matrix.working-directory }}/ios/build/generated/ios
+
       - name: Restore build artifacts from cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/ios-build-test.yml
+++ b/.github/workflows/ios-build-test.yml
@@ -71,10 +71,8 @@ jobs:
       - name: Restore build artifacts from cache
         uses: actions/cache@v3
         with:
-          path: |
-            ${{ matrix.working-directory }}/ios/build
-            ~/Library/Developer/Xcode/DerivedData
-          key: ${{ runner.os }}-ios-build-${{ matrix.working-directory }}-${{ hashFiles(format('{0}/ios/Podfile.lock', matrix.working-directory)) }}
+          path: ~/Library/Developer/Xcode/DerivedData
+          key: ${{ runner.os }}-ios-derived-data-${{ matrix.working-directory }}-${{ hashFiles(format('{0}/ios/Podfile.lock', matrix.working-directory)) }}
 
       - name: Build app
         working-directory: ${{ matrix.working-directory }}

--- a/.github/workflows/ios-build-test.yml
+++ b/.github/workflows/ios-build-test.yml
@@ -63,11 +63,6 @@ jobs:
         working-directory: ${{ matrix.working-directory }}/ios
         run: pod install
 
-      - name: Generate output of codegen
-        uses: actions/upload-artifact@v3
-        with:
-          path: ${{ matrix.working-directory }}/ios/build/generated/ios
-
       - name: Restore build artifacts from cache
         uses: actions/cache@v3
         with:

--- a/Example/ios/Podfile.lock
+++ b/Example/ios/Podfile.lock
@@ -368,7 +368,7 @@ PODS:
     - React-jsi (= 0.70.0)
     - React-logger (= 0.70.0)
     - React-perflogger (= 0.70.0)
-  - RNSVG (13.1.0):
+  - RNSVG (13.2.0):
     - React-Core
   - SocketRocket (0.6.0)
   - Yoga (1.14.0)
@@ -530,7 +530,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
+  DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
   FBLazyVector: 6c76fe46345039d5cf0549e9ddaf5aa169630a4a
   FBReactNativeSpec: 1a270246542f5c52248cb26a96db119cfe3cb760
   Flipper: 26fc4b7382499f1281eb8cb921e5c3ad6de91fe0
@@ -543,7 +543,7 @@ SPEC CHECKSUMS:
   Flipper-RSocket: d9d9ade67cbecf6ac10730304bf5607266dd2541
   FlipperKit: cbdee19bdd4e7f05472a66ce290f1b729ba3cb86
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
+  glog: 476ee3e89abb49e07f822b48323c51c57124b572
   hermes-engine: 8e84f1284180801c1a1b241f443ba64f931ff561
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
@@ -574,7 +574,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: 5499b77c0fd57f346a5f0b36bb79fdb020d17d3e
   React-runtimeexecutor: 80c195ffcafb190f531fdc849dc2d19cb4bb2b34
   ReactCommon: de55f940495d7bf87b5d7bf55b5b15cdd50d7d7b
-  RNSVG: 1153e8eeb34c788841016c517dba9f57f20b762f
+  RNSVG: 07037623c36f12e41312730622d5f6b3656227ca
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
   Yoga: 82c9e8f652789f67d98bed5aef9d6653f71b04a9
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a

--- a/FabricExample/ios/Podfile.lock
+++ b/FabricExample/ios/Podfile.lock
@@ -697,7 +697,7 @@ PODS:
     - React-jsi (= 0.70.0)
     - React-logger (= 0.70.0)
     - React-perflogger (= 0.70.0)
-  - RNSVG (13.1.0):
+  - RNSVG (13.2.0):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -927,7 +927,7 @@ SPEC CHECKSUMS:
   React-rncore: 8858fe6b719170c20c197a8fd2dd53507bdae04b
   React-runtimeexecutor: 80c195ffcafb190f531fdc849dc2d19cb4bb2b34
   ReactCommon: de55f940495d7bf87b5d7bf55b5b15cdd50d7d7b
-  RNSVG: 81cdb77109d5f3e77dcf1dd8045aaaa8144afddf
+  RNSVG: fa7f6f437c90eea1fbc3d142a40365d561824ab3
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
   Yoga: 82c9e8f652789f67d98bed5aef9d6653f71b04a9
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a

--- a/android/src/main/java/com/horcrux/svg/SvgViewManager.java
+++ b/android/src/main/java/com/horcrux/svg/SvgViewManager.java
@@ -176,7 +176,8 @@ class SvgViewManager extends ReactViewManager implements RNSVGSvgViewManagerInte
         method.setAccessible(true);
         method.invoke(view, PointerEvents.parsePointerEvents(pointerEventsStr));
       }
-    } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException ignored) {
+    } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+      e.printStackTrace();
     }
   }
 }

--- a/android/src/main/java/com/horcrux/svg/SvgViewManager.java
+++ b/android/src/main/java/com/horcrux/svg/SvgViewManager.java
@@ -10,13 +10,17 @@ package com.horcrux.svg;
 
 import android.util.SparseArray;
 import com.facebook.react.bridge.Dynamic;
+import com.facebook.react.uimanager.PointerEvents;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewManagerDelegate;
+import com.facebook.react.uimanager.ViewProps;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.viewmanagers.RNSVGSvgViewManagerDelegate;
 import com.facebook.react.viewmanagers.RNSVGSvgViewManagerInterface;
 import com.facebook.react.views.view.ReactViewGroup;
 import com.facebook.react.views.view.ReactViewManager;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -161,5 +165,18 @@ class SvgViewManager extends ReactViewManager implements RNSVGSvgViewManagerInte
 
   public void setBbHeight(SvgView view, @Nullable Double value) {
     view.setBbHeight(value);
+  }
+
+  @ReactProp(name = ViewProps.POINTER_EVENTS)
+  public void setPointerEvents(SvgView view, @Nullable String pointerEventsStr) {
+    try {
+      Class<?> superclass = view.getClass().getSuperclass();
+      if (superclass != null) {
+        Method method = superclass.getDeclaredMethod("setPointerEvents", PointerEvents.class);
+        method.setAccessible(true);
+        method.invoke(view, PointerEvents.parsePointerEvents(pointerEventsStr));
+      }
+    } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException ignored) {
+    }
   }
 }

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGCircleManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGCircleManagerDelegate.java
@@ -56,6 +56,9 @@ public class RNSVGCircleManagerDelegate<T extends View, U extends BaseViewManage
       case "display":
         mViewManager.setDisplay(view, value == null ? null : (String) value);
         break;
+      case "pointerEvents":
+        mViewManager.setPointerEvents(view, value == null ? null : (String) value);
+        break;
       case "fill":
         mViewManager.setFill(view, (ReadableMap) value);
         break;

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGCircleManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGCircleManagerInterface.java
@@ -26,6 +26,7 @@ public interface RNSVGCircleManagerInterface<T extends View> {
   void setClipRule(T view, int value);
   void setResponsible(T view, boolean value);
   void setDisplay(T view, @Nullable String value);
+  void setPointerEvents(T view, @Nullable String value);
   void setFill(T view, @Nullable ReadableMap value);
   void setFillOpacity(T view, float value);
   void setFillRule(T view, int value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGClipPathManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGClipPathManagerDelegate.java
@@ -56,6 +56,9 @@ public class RNSVGClipPathManagerDelegate<T extends View, U extends BaseViewMana
       case "display":
         mViewManager.setDisplay(view, value == null ? null : (String) value);
         break;
+      case "pointerEvents":
+        mViewManager.setPointerEvents(view, value == null ? null : (String) value);
+        break;
       case "fill":
         mViewManager.setFill(view, (ReadableMap) value);
         break;

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGClipPathManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGClipPathManagerInterface.java
@@ -26,6 +26,7 @@ public interface RNSVGClipPathManagerInterface<T extends View> {
   void setClipRule(T view, int value);
   void setResponsible(T view, boolean value);
   void setDisplay(T view, @Nullable String value);
+  void setPointerEvents(T view, @Nullable String value);
   void setFill(T view, @Nullable ReadableMap value);
   void setFillOpacity(T view, float value);
   void setFillRule(T view, int value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGDefsManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGDefsManagerDelegate.java
@@ -55,6 +55,9 @@ public class RNSVGDefsManagerDelegate<T extends View, U extends BaseViewManagerI
       case "display":
         mViewManager.setDisplay(view, value == null ? null : (String) value);
         break;
+      case "pointerEvents":
+        mViewManager.setPointerEvents(view, value == null ? null : (String) value);
+        break;
       default:
         super.setProperty(view, propName, value);
     }

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGDefsManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGDefsManagerInterface.java
@@ -25,4 +25,5 @@ public interface RNSVGDefsManagerInterface<T extends View> {
   void setClipRule(T view, int value);
   void setResponsible(T view, boolean value);
   void setDisplay(T view, @Nullable String value);
+  void setPointerEvents(T view, @Nullable String value);
 }

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGEllipseManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGEllipseManagerDelegate.java
@@ -56,6 +56,9 @@ public class RNSVGEllipseManagerDelegate<T extends View, U extends BaseViewManag
       case "display":
         mViewManager.setDisplay(view, value == null ? null : (String) value);
         break;
+      case "pointerEvents":
+        mViewManager.setPointerEvents(view, value == null ? null : (String) value);
+        break;
       case "fill":
         mViewManager.setFill(view, (ReadableMap) value);
         break;

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGEllipseManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGEllipseManagerInterface.java
@@ -26,6 +26,7 @@ public interface RNSVGEllipseManagerInterface<T extends View> {
   void setClipRule(T view, int value);
   void setResponsible(T view, boolean value);
   void setDisplay(T view, @Nullable String value);
+  void setPointerEvents(T view, @Nullable String value);
   void setFill(T view, @Nullable ReadableMap value);
   void setFillOpacity(T view, float value);
   void setFillRule(T view, int value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGForeignObjectManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGForeignObjectManagerDelegate.java
@@ -56,6 +56,9 @@ public class RNSVGForeignObjectManagerDelegate<T extends View, U extends BaseVie
       case "display":
         mViewManager.setDisplay(view, value == null ? null : (String) value);
         break;
+      case "pointerEvents":
+        mViewManager.setPointerEvents(view, value == null ? null : (String) value);
+        break;
       case "fill":
         mViewManager.setFill(view, (ReadableMap) value);
         break;

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGForeignObjectManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGForeignObjectManagerInterface.java
@@ -26,6 +26,7 @@ public interface RNSVGForeignObjectManagerInterface<T extends View> {
   void setClipRule(T view, int value);
   void setResponsible(T view, boolean value);
   void setDisplay(T view, @Nullable String value);
+  void setPointerEvents(T view, @Nullable String value);
   void setFill(T view, @Nullable ReadableMap value);
   void setFillOpacity(T view, float value);
   void setFillRule(T view, int value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGGroupManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGGroupManagerDelegate.java
@@ -56,6 +56,9 @@ public class RNSVGGroupManagerDelegate<T extends View, U extends BaseViewManager
       case "display":
         mViewManager.setDisplay(view, value == null ? null : (String) value);
         break;
+      case "pointerEvents":
+        mViewManager.setPointerEvents(view, value == null ? null : (String) value);
+        break;
       case "fill":
         mViewManager.setFill(view, (ReadableMap) value);
         break;

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGGroupManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGGroupManagerInterface.java
@@ -26,6 +26,7 @@ public interface RNSVGGroupManagerInterface<T extends View> {
   void setClipRule(T view, int value);
   void setResponsible(T view, boolean value);
   void setDisplay(T view, @Nullable String value);
+  void setPointerEvents(T view, @Nullable String value);
   void setFill(T view, @Nullable ReadableMap value);
   void setFillOpacity(T view, float value);
   void setFillRule(T view, int value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGImageManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGImageManagerDelegate.java
@@ -56,6 +56,9 @@ public class RNSVGImageManagerDelegate<T extends View, U extends BaseViewManager
       case "display":
         mViewManager.setDisplay(view, value == null ? null : (String) value);
         break;
+      case "pointerEvents":
+        mViewManager.setPointerEvents(view, value == null ? null : (String) value);
+        break;
       case "fill":
         mViewManager.setFill(view, (ReadableMap) value);
         break;

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGImageManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGImageManagerInterface.java
@@ -26,6 +26,7 @@ public interface RNSVGImageManagerInterface<T extends View> {
   void setClipRule(T view, int value);
   void setResponsible(T view, boolean value);
   void setDisplay(T view, @Nullable String value);
+  void setPointerEvents(T view, @Nullable String value);
   void setFill(T view, @Nullable ReadableMap value);
   void setFillOpacity(T view, float value);
   void setFillRule(T view, int value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGLineManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGLineManagerDelegate.java
@@ -56,6 +56,9 @@ public class RNSVGLineManagerDelegate<T extends View, U extends BaseViewManagerI
       case "display":
         mViewManager.setDisplay(view, value == null ? null : (String) value);
         break;
+      case "pointerEvents":
+        mViewManager.setPointerEvents(view, value == null ? null : (String) value);
+        break;
       case "fill":
         mViewManager.setFill(view, (ReadableMap) value);
         break;

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGLineManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGLineManagerInterface.java
@@ -26,6 +26,7 @@ public interface RNSVGLineManagerInterface<T extends View> {
   void setClipRule(T view, int value);
   void setResponsible(T view, boolean value);
   void setDisplay(T view, @Nullable String value);
+  void setPointerEvents(T view, @Nullable String value);
   void setFill(T view, @Nullable ReadableMap value);
   void setFillOpacity(T view, float value);
   void setFillRule(T view, int value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGLinearGradientManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGLinearGradientManagerDelegate.java
@@ -55,6 +55,9 @@ public class RNSVGLinearGradientManagerDelegate<T extends View, U extends BaseVi
       case "display":
         mViewManager.setDisplay(view, value == null ? null : (String) value);
         break;
+      case "pointerEvents":
+        mViewManager.setPointerEvents(view, value == null ? null : (String) value);
+        break;
       case "x1":
         if (value instanceof String) {
           mViewManager.setX1(view, (String) value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGLinearGradientManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGLinearGradientManagerInterface.java
@@ -25,6 +25,7 @@ public interface RNSVGLinearGradientManagerInterface<T extends View> {
   void setClipRule(T view, int value);
   void setResponsible(T view, boolean value);
   void setDisplay(T view, @Nullable String value);
+  void setPointerEvents(T view, @Nullable String value);
   void setX1(T view, @Nullable String value);
   void setX1(T view, @Nullable Double value);
   void setY1(T view, @Nullable String value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGMarkerManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGMarkerManagerDelegate.java
@@ -56,6 +56,9 @@ public class RNSVGMarkerManagerDelegate<T extends View, U extends BaseViewManage
       case "display":
         mViewManager.setDisplay(view, value == null ? null : (String) value);
         break;
+      case "pointerEvents":
+        mViewManager.setPointerEvents(view, value == null ? null : (String) value);
+        break;
       case "fill":
         mViewManager.setFill(view, (ReadableMap) value);
         break;

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGMarkerManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGMarkerManagerInterface.java
@@ -26,6 +26,7 @@ public interface RNSVGMarkerManagerInterface<T extends View> {
   void setClipRule(T view, int value);
   void setResponsible(T view, boolean value);
   void setDisplay(T view, @Nullable String value);
+  void setPointerEvents(T view, @Nullable String value);
   void setFill(T view, @Nullable ReadableMap value);
   void setFillOpacity(T view, float value);
   void setFillRule(T view, int value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGMaskManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGMaskManagerDelegate.java
@@ -56,6 +56,9 @@ public class RNSVGMaskManagerDelegate<T extends View, U extends BaseViewManagerI
       case "display":
         mViewManager.setDisplay(view, value == null ? null : (String) value);
         break;
+      case "pointerEvents":
+        mViewManager.setPointerEvents(view, value == null ? null : (String) value);
+        break;
       case "fill":
         mViewManager.setFill(view, (ReadableMap) value);
         break;

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGMaskManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGMaskManagerInterface.java
@@ -26,6 +26,7 @@ public interface RNSVGMaskManagerInterface<T extends View> {
   void setClipRule(T view, int value);
   void setResponsible(T view, boolean value);
   void setDisplay(T view, @Nullable String value);
+  void setPointerEvents(T view, @Nullable String value);
   void setFill(T view, @Nullable ReadableMap value);
   void setFillOpacity(T view, float value);
   void setFillRule(T view, int value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGPathManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGPathManagerDelegate.java
@@ -56,6 +56,9 @@ public class RNSVGPathManagerDelegate<T extends View, U extends BaseViewManagerI
       case "display":
         mViewManager.setDisplay(view, value == null ? null : (String) value);
         break;
+      case "pointerEvents":
+        mViewManager.setPointerEvents(view, value == null ? null : (String) value);
+        break;
       case "fill":
         mViewManager.setFill(view, (ReadableMap) value);
         break;

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGPathManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGPathManagerInterface.java
@@ -26,6 +26,7 @@ public interface RNSVGPathManagerInterface<T extends View> {
   void setClipRule(T view, int value);
   void setResponsible(T view, boolean value);
   void setDisplay(T view, @Nullable String value);
+  void setPointerEvents(T view, @Nullable String value);
   void setFill(T view, @Nullable ReadableMap value);
   void setFillOpacity(T view, float value);
   void setFillRule(T view, int value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGPatternManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGPatternManagerDelegate.java
@@ -56,6 +56,9 @@ public class RNSVGPatternManagerDelegate<T extends View, U extends BaseViewManag
       case "display":
         mViewManager.setDisplay(view, value == null ? null : (String) value);
         break;
+      case "pointerEvents":
+        mViewManager.setPointerEvents(view, value == null ? null : (String) value);
+        break;
       case "fill":
         mViewManager.setFill(view, (ReadableMap) value);
         break;

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGPatternManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGPatternManagerInterface.java
@@ -26,6 +26,7 @@ public interface RNSVGPatternManagerInterface<T extends View> {
   void setClipRule(T view, int value);
   void setResponsible(T view, boolean value);
   void setDisplay(T view, @Nullable String value);
+  void setPointerEvents(T view, @Nullable String value);
   void setFill(T view, @Nullable ReadableMap value);
   void setFillOpacity(T view, float value);
   void setFillRule(T view, int value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGRadialGradientManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGRadialGradientManagerDelegate.java
@@ -55,6 +55,9 @@ public class RNSVGRadialGradientManagerDelegate<T extends View, U extends BaseVi
       case "display":
         mViewManager.setDisplay(view, value == null ? null : (String) value);
         break;
+      case "pointerEvents":
+        mViewManager.setPointerEvents(view, value == null ? null : (String) value);
+        break;
       case "fx":
         if (value instanceof String) {
           mViewManager.setFx(view, (String) value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGRadialGradientManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGRadialGradientManagerInterface.java
@@ -25,6 +25,7 @@ public interface RNSVGRadialGradientManagerInterface<T extends View> {
   void setClipRule(T view, int value);
   void setResponsible(T view, boolean value);
   void setDisplay(T view, @Nullable String value);
+  void setPointerEvents(T view, @Nullable String value);
   void setFx(T view, @Nullable String value);
   void setFx(T view, @Nullable Double value);
   void setFy(T view, @Nullable String value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGRectManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGRectManagerDelegate.java
@@ -56,6 +56,9 @@ public class RNSVGRectManagerDelegate<T extends View, U extends BaseViewManagerI
       case "display":
         mViewManager.setDisplay(view, value == null ? null : (String) value);
         break;
+      case "pointerEvents":
+        mViewManager.setPointerEvents(view, value == null ? null : (String) value);
+        break;
       case "fill":
         mViewManager.setFill(view, (ReadableMap) value);
         break;

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGRectManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGRectManagerInterface.java
@@ -26,6 +26,7 @@ public interface RNSVGRectManagerInterface<T extends View> {
   void setClipRule(T view, int value);
   void setResponsible(T view, boolean value);
   void setDisplay(T view, @Nullable String value);
+  void setPointerEvents(T view, @Nullable String value);
   void setFill(T view, @Nullable ReadableMap value);
   void setFillOpacity(T view, float value);
   void setFillRule(T view, int value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGSvgViewManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGSvgViewManagerDelegate.java
@@ -64,6 +64,9 @@ public class RNSVGSvgViewManagerDelegate<T extends View, U extends BaseViewManag
       case "color":
         mViewManager.setColor(view, ColorPropConverter.getColor(value, view.getContext()));
         break;
+      case "pointerEvents":
+        mViewManager.setPointerEvents(view, value == null ? null : (String) value);
+        break;
       default:
         super.setProperty(view, propName, value);
     }

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGSvgViewManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGSvgViewManagerInterface.java
@@ -25,4 +25,5 @@ public interface RNSVGSvgViewManagerInterface<T extends View> {
   void setMeetOrSlice(T view, int value);
   void setTintColor(T view, @Nullable Integer value);
   void setColor(T view, @Nullable Integer value);
+  void setPointerEvents(T view, @Nullable String value);
 }

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGSymbolManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGSymbolManagerDelegate.java
@@ -56,6 +56,9 @@ public class RNSVGSymbolManagerDelegate<T extends View, U extends BaseViewManage
       case "display":
         mViewManager.setDisplay(view, value == null ? null : (String) value);
         break;
+      case "pointerEvents":
+        mViewManager.setPointerEvents(view, value == null ? null : (String) value);
+        break;
       case "fill":
         mViewManager.setFill(view, (ReadableMap) value);
         break;

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGSymbolManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGSymbolManagerInterface.java
@@ -26,6 +26,7 @@ public interface RNSVGSymbolManagerInterface<T extends View> {
   void setClipRule(T view, int value);
   void setResponsible(T view, boolean value);
   void setDisplay(T view, @Nullable String value);
+  void setPointerEvents(T view, @Nullable String value);
   void setFill(T view, @Nullable ReadableMap value);
   void setFillOpacity(T view, float value);
   void setFillRule(T view, int value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGTSpanManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGTSpanManagerDelegate.java
@@ -56,6 +56,9 @@ public class RNSVGTSpanManagerDelegate<T extends View, U extends BaseViewManager
       case "display":
         mViewManager.setDisplay(view, value == null ? null : (String) value);
         break;
+      case "pointerEvents":
+        mViewManager.setPointerEvents(view, value == null ? null : (String) value);
+        break;
       case "fill":
         mViewManager.setFill(view, (ReadableMap) value);
         break;

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGTSpanManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGTSpanManagerInterface.java
@@ -26,6 +26,7 @@ public interface RNSVGTSpanManagerInterface<T extends View> {
   void setClipRule(T view, int value);
   void setResponsible(T view, boolean value);
   void setDisplay(T view, @Nullable String value);
+  void setPointerEvents(T view, @Nullable String value);
   void setFill(T view, @Nullable ReadableMap value);
   void setFillOpacity(T view, float value);
   void setFillRule(T view, int value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGTextManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGTextManagerDelegate.java
@@ -56,6 +56,9 @@ public class RNSVGTextManagerDelegate<T extends View, U extends BaseViewManagerI
       case "display":
         mViewManager.setDisplay(view, value == null ? null : (String) value);
         break;
+      case "pointerEvents":
+        mViewManager.setPointerEvents(view, value == null ? null : (String) value);
+        break;
       case "fill":
         mViewManager.setFill(view, (ReadableMap) value);
         break;

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGTextManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGTextManagerInterface.java
@@ -26,6 +26,7 @@ public interface RNSVGTextManagerInterface<T extends View> {
   void setClipRule(T view, int value);
   void setResponsible(T view, boolean value);
   void setDisplay(T view, @Nullable String value);
+  void setPointerEvents(T view, @Nullable String value);
   void setFill(T view, @Nullable ReadableMap value);
   void setFillOpacity(T view, float value);
   void setFillRule(T view, int value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGTextPathManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGTextPathManagerDelegate.java
@@ -56,6 +56,9 @@ public class RNSVGTextPathManagerDelegate<T extends View, U extends BaseViewMana
       case "display":
         mViewManager.setDisplay(view, value == null ? null : (String) value);
         break;
+      case "pointerEvents":
+        mViewManager.setPointerEvents(view, value == null ? null : (String) value);
+        break;
       case "fill":
         mViewManager.setFill(view, (ReadableMap) value);
         break;

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGTextPathManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGTextPathManagerInterface.java
@@ -26,6 +26,7 @@ public interface RNSVGTextPathManagerInterface<T extends View> {
   void setClipRule(T view, int value);
   void setResponsible(T view, boolean value);
   void setDisplay(T view, @Nullable String value);
+  void setPointerEvents(T view, @Nullable String value);
   void setFill(T view, @Nullable ReadableMap value);
   void setFillOpacity(T view, float value);
   void setFillRule(T view, int value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGUseManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGUseManagerDelegate.java
@@ -56,6 +56,9 @@ public class RNSVGUseManagerDelegate<T extends View, U extends BaseViewManagerIn
       case "display":
         mViewManager.setDisplay(view, value == null ? null : (String) value);
         break;
+      case "pointerEvents":
+        mViewManager.setPointerEvents(view, value == null ? null : (String) value);
+        break;
       case "fill":
         mViewManager.setFill(view, (ReadableMap) value);
         break;

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGUseManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGUseManagerInterface.java
@@ -26,6 +26,7 @@ public interface RNSVGUseManagerInterface<T extends View> {
   void setClipRule(T view, int value);
   void setResponsible(T view, boolean value);
   void setDisplay(T view, @Nullable String value);
+  void setPointerEvents(T view, @Nullable String value);
   void setFill(T view, @Nullable ReadableMap value);
   void setFillOpacity(T view, float value);
   void setFillRule(T view, int value);

--- a/apple/Utils/RNSVGFabricConversions.h
+++ b/apple/Utils/RNSVGFabricConversions.h
@@ -69,7 +69,7 @@ void setCommonNodeProps(T nodeProps, RNSVGNode *node)
   node.responsible = nodeProps.responsible;
   // onLayout
   node.display = RCTNSStringFromStringNilIfEmpty(nodeProps.display);
-  NSString *pointerEventsString = RCTNSStringFromString(nodeProps.pointerEvents);
+  NSString *pointerEventsString = RCTNSStringFromStringNilIfEmpty(nodeProps.pointerEvents);
   if ([pointerEventsString isEqualToString:@"auto"]) {
     node.pointerEvents = RCTPointerEventsUnspecified;
   } else if ([pointerEventsString isEqualToString:@"none"]) {

--- a/apple/Utils/RNSVGFabricConversions.h
+++ b/apple/Utils/RNSVGFabricConversions.h
@@ -69,7 +69,8 @@ void setCommonNodeProps(T nodeProps, RNSVGNode *node)
   node.responsible = nodeProps.responsible;
   // onLayout
   node.display = RCTNSStringFromStringNilIfEmpty(nodeProps.display);
-  NSString *pointerEventsString = RCTNSStringFromStringNilIfEmpty(nodeProps.pointerEvents);
+  std::string pointerEvents = nodeProps.pointerEvents;
+  NSString *pointerEventsString = RCTNSStringFromStringNilIfEmpty(pointerEvents);
   if ([pointerEventsString isEqualToString:@"auto"]) {
     node.pointerEvents = RCTPointerEventsUnspecified;
   } else if ([pointerEventsString isEqualToString:@"none"]) {

--- a/apple/Utils/RNSVGFabricConversions.h
+++ b/apple/Utils/RNSVGFabricConversions.h
@@ -69,17 +69,17 @@ void setCommonNodeProps(T nodeProps, RNSVGNode *node)
   node.responsible = nodeProps.responsible;
   // onLayout
   node.display = RCTNSStringFromStringNilIfEmpty(nodeProps.display);
-  switch (nodeProps.pointerEvents) {
-    case facebook::react::PointerEventsMode::Auto:
-      node.pointerEvents = RCTPointerEventsUnspecified;
-    case facebook::react::PointerEventsMode::None:
-      node.pointerEvents = RCTPointerEventsNone;
-    case facebook::react::PointerEventsMode::BoxNone:
-      node.pointerEvents = RCTPointerEventsBoxNone;
-    case facebook::react::PointerEventsMode::BoxOnly:
-      node.pointerEvents = RCTPointerEventsBoxOnly;
-    default:
-      node.pointerEvents = RCTPointerEventsUnspecified;
+  NSString *pointerEventsString = RCTNSStringFromString(nodeProps.pointerEvents);
+  if ([pointerEventsString isEqualToString:@"auto"]) {
+    node.pointerEvents = RCTPointerEventsUnspecified;
+  } else if ([pointerEventsString isEqualToString:@"none"]) {
+    node.pointerEvents = RCTPointerEventsNone;
+  } else if ([pointerEventsString isEqualToString:@"box-none"]) {
+    node.pointerEvents = RCTPointerEventsNone;
+  } else if ([pointerEventsString isEqualToString:@"box-only"]) {
+    node.pointerEvents = RCTPointerEventsNone;
+  } else {
+    node.pointerEvents = RCTPointerEventsUnspecified;
   }
 }
 

--- a/src/fabric/CircleNativeComponent.ts
+++ b/src/fabric/CircleNativeComponent.ts
@@ -1,16 +1,16 @@
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
-import type { ViewProps, ColorValue } from 'react-native';
+import type { ColorValue } from 'react-native';
 import type {
   Float,
   Int32,
   WithDefault,
 } from 'react-native/Libraries/Types/CodegenTypes';
+import type { ViewProps } from './utils';
 
 interface SvgNodeCommonProps {
   name?: string;
   opacity?: WithDefault<Float, 1.0>;
   matrix?: ReadonlyArray<Float>;
-  // transform?: ____TransformStyle_Internal, // CATransform3D, custom handling
   mask?: string;
   markerStart?: string;
   markerMid?: string;
@@ -19,6 +19,7 @@ interface SvgNodeCommonProps {
   clipRule?: WithDefault<Int32, 0>;
   responsible?: boolean;
   display?: string;
+  pointerEvents?: string;
 }
 
 type ColorStruct = Readonly<{

--- a/src/fabric/ClipPathNativeComponent.ts
+++ b/src/fabric/ClipPathNativeComponent.ts
@@ -1,16 +1,16 @@
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
-import type { ColorValue, ViewProps } from 'react-native';
+import type { ColorValue } from 'react-native';
 import type {
   Float,
   Int32,
   WithDefault,
 } from 'react-native/Libraries/Types/CodegenTypes';
+import type { ViewProps } from './utils';
 
 interface SvgNodeCommonProps {
   name?: string;
   opacity?: WithDefault<Float, 1.0>;
   matrix?: ReadonlyArray<Float>;
-  // transform?: ____TransformStyle_Internal, // CATransform3D, custom handling
   mask?: string;
   markerStart?: string;
   markerMid?: string;
@@ -19,6 +19,7 @@ interface SvgNodeCommonProps {
   clipRule?: WithDefault<Int32, 0>;
   responsible?: boolean;
   display?: string;
+  pointerEvents?: string;
 }
 
 type ColorStruct = Readonly<{

--- a/src/fabric/DefsNativeComponent.ts
+++ b/src/fabric/DefsNativeComponent.ts
@@ -1,16 +1,15 @@
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
-import type { ViewProps } from 'react-native';
 import {
   Float,
   Int32,
   WithDefault,
 } from 'react-native/Libraries/Types/CodegenTypes';
+import type { ViewProps } from './utils';
 
 interface SvgNodeCommonProps {
   name?: string;
   opacity?: WithDefault<Float, 1.0>;
   matrix?: ReadonlyArray<Float>;
-  // transform?: ____TransformStyle_Internal, // CATransform3D, custom handling
   mask?: string;
   markerStart?: string;
   markerMid?: string;
@@ -19,6 +18,7 @@ interface SvgNodeCommonProps {
   clipRule?: WithDefault<Int32, 0>;
   responsible?: boolean;
   display?: string;
+  pointerEvents?: string;
 }
 
 interface NativeProps extends ViewProps, SvgNodeCommonProps {}

--- a/src/fabric/EllipseNativeComponent.ts
+++ b/src/fabric/EllipseNativeComponent.ts
@@ -1,16 +1,16 @@
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
-import type { ViewProps, ColorValue } from 'react-native';
+import type { ColorValue } from 'react-native';
 import type {
   Float,
   Int32,
   WithDefault,
 } from 'react-native/Libraries/Types/CodegenTypes';
+import type { ViewProps } from './utils';
 
 interface SvgNodeCommonProps {
   name?: string;
   opacity?: WithDefault<Float, 1.0>;
   matrix?: ReadonlyArray<Float>;
-  // transform?: ____TransformStyle_Internal, // CATransform3D, custom handling
   mask?: string;
   markerStart?: string;
   markerMid?: string;
@@ -19,6 +19,7 @@ interface SvgNodeCommonProps {
   clipRule?: WithDefault<Int32, 0>;
   responsible?: boolean;
   display?: string;
+  pointerEvents?: string;
 }
 
 type ColorStruct = Readonly<{

--- a/src/fabric/ForeignObjectNativeComponent.ts
+++ b/src/fabric/ForeignObjectNativeComponent.ts
@@ -1,16 +1,16 @@
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
-import type { ViewProps, ColorValue } from 'react-native';
+import type { ColorValue } from 'react-native';
 import type {
   Float,
   Int32,
   WithDefault,
 } from 'react-native/Libraries/Types/CodegenTypes';
+import type { ViewProps } from './utils';
 
 interface SvgNodeCommonProps {
   name?: string;
   opacity?: WithDefault<Float, 1.0>;
   matrix?: ReadonlyArray<Float>;
-  // transform?: ____TransformStyle_Internal, // CATransform3D, custom handling
   mask?: string;
   markerStart?: string;
   markerMid?: string;
@@ -19,6 +19,7 @@ interface SvgNodeCommonProps {
   clipRule?: WithDefault<Int32, 0>;
   responsible?: boolean;
   display?: string;
+  pointerEvents?: string;
 }
 
 type ColorStruct = Readonly<{

--- a/src/fabric/GroupNativeComponent.ts
+++ b/src/fabric/GroupNativeComponent.ts
@@ -1,16 +1,16 @@
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
-import type { ViewProps, ColorValue } from 'react-native';
+import type { ColorValue } from 'react-native';
 import type {
   Float,
   Int32,
   WithDefault,
 } from 'react-native/Libraries/Types/CodegenTypes';
+import type { ViewProps } from './utils';
 
 interface SvgNodeCommonProps {
   name?: string;
   opacity?: WithDefault<Float, 1.0>;
   matrix?: ReadonlyArray<Float>;
-  // transform?: ____TransformStyle_Internal, // CATransform3D, custom handling
   mask?: string;
   markerStart?: string;
   markerMid?: string;
@@ -19,6 +19,7 @@ interface SvgNodeCommonProps {
   clipRule?: WithDefault<Int32, 0>;
   responsible?: boolean;
   display?: string;
+  pointerEvents?: string;
 }
 
 type ColorStruct = Readonly<{

--- a/src/fabric/ImageNativeComponent.ts
+++ b/src/fabric/ImageNativeComponent.ts
@@ -1,7 +1,6 @@
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 // TODO: import ImageSource from codegen types when it is available
 import type {
-  ViewProps,
   ColorValue,
   ImageSourcePropType as ImageSource,
 } from 'react-native';
@@ -10,12 +9,12 @@ import type {
   Int32,
   WithDefault,
 } from 'react-native/Libraries/Types/CodegenTypes';
+import type { ViewProps } from './utils';
 
 interface SvgNodeCommonProps {
   name?: string;
   opacity?: WithDefault<Float, 1.0>;
   matrix?: ReadonlyArray<Float>;
-  // transform?: ____TransformStyle_Internal, // CATransform3D, custom handling
   mask?: string;
   markerStart?: string;
   markerMid?: string;
@@ -24,6 +23,7 @@ interface SvgNodeCommonProps {
   clipRule?: WithDefault<Int32, 0>;
   responsible?: boolean;
   display?: string;
+  pointerEvents?: string;
 }
 
 type ColorStruct = Readonly<{

--- a/src/fabric/LineNativeComponent.ts
+++ b/src/fabric/LineNativeComponent.ts
@@ -1,16 +1,16 @@
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
-import type { ViewProps, ColorValue } from 'react-native';
+import type { ColorValue } from 'react-native';
 import type {
   Float,
   Int32,
   WithDefault,
 } from 'react-native/Libraries/Types/CodegenTypes';
+import type { ViewProps } from './utils';
 
 interface SvgNodeCommonProps {
   name?: string;
   opacity?: WithDefault<Float, 1.0>;
   matrix?: ReadonlyArray<Float>;
-  // transform?: ____TransformStyle_Internal, // CATransform3D, custom handling
   mask?: string;
   markerStart?: string;
   markerMid?: string;
@@ -19,6 +19,7 @@ interface SvgNodeCommonProps {
   clipRule?: WithDefault<Int32, 0>;
   responsible?: boolean;
   display?: string;
+  pointerEvents?: string;
 }
 
 type ColorStruct = Readonly<{

--- a/src/fabric/LinearGradientNativeComponent.ts
+++ b/src/fabric/LinearGradientNativeComponent.ts
@@ -1,16 +1,15 @@
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
-import type { ViewProps } from 'react-native';
 import type {
   Float,
   Int32,
   WithDefault,
 } from 'react-native/Libraries/Types/CodegenTypes';
+import type { ViewProps } from './utils';
 
 interface SvgNodeCommonProps {
   name?: string;
   opacity?: WithDefault<Float, 1.0>;
   matrix?: ReadonlyArray<Float>;
-  // transform?: ____TransformStyle_Internal, // CATransform3D, custom handling
   mask?: string;
   markerStart?: string;
   markerMid?: string;
@@ -19,6 +18,7 @@ interface SvgNodeCommonProps {
   clipRule?: WithDefault<Int32, 0>;
   responsible?: boolean;
   display?: string;
+  pointerEvents?: string;
 }
 
 interface NativeProps extends ViewProps, SvgNodeCommonProps {

--- a/src/fabric/MarkerNativeComponent.ts
+++ b/src/fabric/MarkerNativeComponent.ts
@@ -1,16 +1,16 @@
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
-import type { ViewProps, ColorValue } from 'react-native';
+import type { ColorValue } from 'react-native';
 import type {
   Float,
   Int32,
   WithDefault,
 } from 'react-native/Libraries/Types/CodegenTypes';
+import type { ViewProps } from './utils';
 
 interface SvgNodeCommonProps {
   name?: string;
   opacity?: WithDefault<Float, 1.0>;
   matrix?: ReadonlyArray<Float>;
-  // transform?: ____TransformStyle_Internal, // CATransform3D, custom handling
   mask?: string;
   markerStart?: string;
   markerMid?: string;
@@ -19,6 +19,7 @@ interface SvgNodeCommonProps {
   clipRule?: WithDefault<Int32, 0>;
   responsible?: boolean;
   display?: string;
+  pointerEvents?: string;
 }
 
 type ColorStruct = Readonly<{

--- a/src/fabric/MaskNativeComponent.ts
+++ b/src/fabric/MaskNativeComponent.ts
@@ -1,16 +1,16 @@
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
-import type { ViewProps, ColorValue } from 'react-native';
+import type { ColorValue } from 'react-native';
 import type {
   Float,
   Int32,
   WithDefault,
 } from 'react-native/Libraries/Types/CodegenTypes';
+import type { ViewProps } from './utils';
 
 interface SvgNodeCommonProps {
   name?: string;
   opacity?: WithDefault<Float, 1.0>;
   matrix?: ReadonlyArray<Float>;
-  // transform?: ____TransformStyle_Internal, // CATransform3D, custom handling
   mask?: string;
   markerStart?: string;
   markerMid?: string;
@@ -19,6 +19,7 @@ interface SvgNodeCommonProps {
   clipRule?: WithDefault<Int32, 0>;
   responsible?: boolean;
   display?: string;
+  pointerEvents?: string;
 }
 
 type ColorStruct = Readonly<{

--- a/src/fabric/PathNativeComponent.ts
+++ b/src/fabric/PathNativeComponent.ts
@@ -1,16 +1,16 @@
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
-import type { ViewProps, ColorValue } from 'react-native';
+import type { ColorValue } from 'react-native';
 import type {
   Float,
   Int32,
   WithDefault,
 } from 'react-native/Libraries/Types/CodegenTypes';
+import type { ViewProps } from './utils';
 
 interface SvgNodeCommonProps {
   name?: string;
   opacity?: WithDefault<Float, 1.0>;
   matrix?: ReadonlyArray<Float>;
-  // transform?: ____TransformStyle_Internal, // CATransform3D, custom handling
   mask?: string;
   markerStart?: string;
   markerMid?: string;
@@ -19,6 +19,7 @@ interface SvgNodeCommonProps {
   clipRule?: WithDefault<Int32, 0>;
   responsible?: boolean;
   display?: string;
+  pointerEvents?: string;
 }
 
 type ColorStruct = Readonly<{

--- a/src/fabric/PatternNativeComponent.ts
+++ b/src/fabric/PatternNativeComponent.ts
@@ -1,16 +1,16 @@
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
-import type { ViewProps, ColorValue } from 'react-native';
+import type { ColorValue } from 'react-native';
 import type {
   Float,
   Int32,
   WithDefault,
 } from 'react-native/Libraries/Types/CodegenTypes';
+import type { ViewProps } from './utils';
 
 interface SvgNodeCommonProps {
   name?: string;
   opacity?: WithDefault<Float, 1.0>;
   matrix?: ReadonlyArray<Float>;
-  // transform?: ____TransformStyle_Internal, // CATransform3D, custom handling
   mask?: string;
   markerStart?: string;
   markerMid?: string;
@@ -19,6 +19,7 @@ interface SvgNodeCommonProps {
   clipRule?: WithDefault<Int32, 0>;
   responsible?: boolean;
   display?: string;
+  pointerEvents?: string;
 }
 
 type ColorStruct = Readonly<{

--- a/src/fabric/RadialGradientNativeComponent.ts
+++ b/src/fabric/RadialGradientNativeComponent.ts
@@ -1,16 +1,15 @@
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
-import type { ViewProps } from 'react-native';
 import type {
   Float,
   Int32,
   WithDefault,
 } from 'react-native/Libraries/Types/CodegenTypes';
+import type { ViewProps } from './utils';
 
 interface SvgNodeCommonProps {
   name?: string;
   opacity?: WithDefault<Float, 1.0>;
   matrix?: ReadonlyArray<Float>;
-  // transform?: ____TransformStyle_Internal, // CATransform3D, custom handling
   mask?: string;
   markerStart?: string;
   markerMid?: string;
@@ -19,6 +18,7 @@ interface SvgNodeCommonProps {
   clipRule?: WithDefault<Int32, 0>;
   responsible?: boolean;
   display?: string;
+  pointerEvents?: string;
 }
 
 interface NativeProps extends ViewProps, SvgNodeCommonProps {

--- a/src/fabric/RectNativeComponent.ts
+++ b/src/fabric/RectNativeComponent.ts
@@ -1,16 +1,16 @@
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
-import type { ViewProps, ColorValue } from 'react-native';
+import type { ColorValue } from 'react-native';
 import type {
   Float,
   Int32,
   WithDefault,
 } from 'react-native/Libraries/Types/CodegenTypes';
+import type { ViewProps } from './utils';
 
 interface SvgNodeCommonProps {
   name?: string;
   opacity?: WithDefault<Float, 1.0>;
   matrix?: ReadonlyArray<Float>;
-  // transform?: ____TransformStyle_Internal, // CATransform3D, custom handling
   mask?: string;
   markerStart?: string;
   markerMid?: string;
@@ -19,6 +19,7 @@ interface SvgNodeCommonProps {
   clipRule?: WithDefault<Int32, 0>;
   responsible?: boolean;
   display?: string;
+  pointerEvents?: string;
 }
 
 type ColorStruct = Readonly<{

--- a/src/fabric/SvgViewNativeComponent.ts
+++ b/src/fabric/SvgViewNativeComponent.ts
@@ -1,5 +1,5 @@
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
-import type { ViewProps, ColorValue } from 'react-native';
+import type { ColorValue, ViewProps } from 'react-native';
 import type { Float, Int32 } from 'react-native/Libraries/Types/CodegenTypes';
 
 interface NativeProps extends ViewProps {

--- a/src/fabric/SvgViewNativeComponent.ts
+++ b/src/fabric/SvgViewNativeComponent.ts
@@ -1,6 +1,7 @@
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
-import type { ColorValue, ViewProps } from 'react-native';
+import type { ColorValue } from 'react-native';
 import type { Float, Int32 } from 'react-native/Libraries/Types/CodegenTypes';
+import type { ViewProps } from './utils';
 
 interface NativeProps extends ViewProps {
   bbWidth: string;
@@ -13,6 +14,7 @@ interface NativeProps extends ViewProps {
   meetOrSlice: Int32;
   tintColor: ColorValue;
   color: ColorValue;
+  pointerEvents?: string;
 }
 
 export default codegenNativeComponent<NativeProps>('RNSVGSvgView');

--- a/src/fabric/SymbolNativeComponent.ts
+++ b/src/fabric/SymbolNativeComponent.ts
@@ -1,16 +1,16 @@
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
-import type { ViewProps, ColorValue } from 'react-native';
+import type { ColorValue } from 'react-native';
 import type {
   Float,
   Int32,
   WithDefault,
 } from 'react-native/Libraries/Types/CodegenTypes';
+import type { ViewProps } from './utils';
 
 interface SvgNodeCommonProps {
   name?: string;
   opacity?: WithDefault<Float, 1.0>;
   matrix?: ReadonlyArray<Float>;
-  // transform?: ____TransformStyle_Internal, // CATransform3D, custom handling
   mask?: string;
   markerStart?: string;
   markerMid?: string;
@@ -19,6 +19,7 @@ interface SvgNodeCommonProps {
   clipRule?: WithDefault<Int32, 0>;
   responsible?: boolean;
   display?: string;
+  pointerEvents?: string;
 }
 
 type ColorStruct = Readonly<{

--- a/src/fabric/TSpanNativeComponent.ts
+++ b/src/fabric/TSpanNativeComponent.ts
@@ -1,16 +1,16 @@
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
-import type { ViewProps, ColorValue } from 'react-native';
+import type { ColorValue } from 'react-native';
 import type {
   Float,
   Int32,
   WithDefault,
 } from 'react-native/Libraries/Types/CodegenTypes';
+import type { ViewProps } from './utils';
 
 interface SvgNodeCommonProps {
   name?: string;
   opacity?: WithDefault<Float, 1.0>;
   matrix?: ReadonlyArray<Float>;
-  // transform?: ____TransformStyle_Internal, // CATransform3D, custom handling
   mask?: string;
   markerStart?: string;
   markerMid?: string;
@@ -19,6 +19,7 @@ interface SvgNodeCommonProps {
   clipRule?: WithDefault<Int32, 0>;
   responsible?: boolean;
   display?: string;
+  pointerEvents?: string;
 }
 
 type ColorStruct = Readonly<{

--- a/src/fabric/TextNativeComponent.ts
+++ b/src/fabric/TextNativeComponent.ts
@@ -1,16 +1,16 @@
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
-import type { ViewProps, ColorValue } from 'react-native';
+import type { ColorValue } from 'react-native';
 import type {
   Float,
   Int32,
   WithDefault,
 } from 'react-native/Libraries/Types/CodegenTypes';
+import type { ViewProps } from './utils';
 
 interface SvgNodeCommonProps {
   name?: string;
   opacity?: WithDefault<Float, 1.0>;
   matrix?: ReadonlyArray<Float>;
-  // transform?: ____TransformStyle_Internal, // CATransform3D, custom handling
   mask?: string;
   markerStart?: string;
   markerMid?: string;
@@ -19,6 +19,7 @@ interface SvgNodeCommonProps {
   clipRule?: WithDefault<Int32, 0>;
   responsible?: boolean;
   display?: string;
+  pointerEvents?: string;
 }
 
 type ColorStruct = Readonly<{

--- a/src/fabric/TextPathNativeComponent.ts
+++ b/src/fabric/TextPathNativeComponent.ts
@@ -1,16 +1,16 @@
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
-import type { ViewProps, ColorValue } from 'react-native';
+import type { ColorValue } from 'react-native';
 import type {
   Float,
   Int32,
   WithDefault,
 } from 'react-native/Libraries/Types/CodegenTypes';
+import type { ViewProps } from './utils';
 
 interface SvgNodeCommonProps {
   name?: string;
   opacity?: WithDefault<Float, 1.0>;
   matrix?: ReadonlyArray<Float>;
-  // transform?: ____TransformStyle_Internal, // CATransform3D, custom handling
   mask?: string;
   markerStart?: string;
   markerMid?: string;
@@ -19,6 +19,7 @@ interface SvgNodeCommonProps {
   clipRule?: WithDefault<Int32, 0>;
   responsible?: boolean;
   display?: string;
+  pointerEvents?: string;
 }
 
 type ColorStruct = Readonly<{

--- a/src/fabric/UseNativeComponent.ts
+++ b/src/fabric/UseNativeComponent.ts
@@ -1,16 +1,16 @@
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
-import type { ViewProps, ColorValue } from 'react-native';
+import type { ColorValue } from 'react-native';
 import type {
   Float,
   Int32,
   WithDefault,
 } from 'react-native/Libraries/Types/CodegenTypes';
+import type { ViewProps } from './utils';
 
 interface SvgNodeCommonProps {
   name?: string;
   opacity?: WithDefault<Float, 1.0>;
   matrix?: ReadonlyArray<Float>;
-  // transform?: ____TransformStyle_Internal, // CATransform3D, custom handling
   mask?: string;
   markerStart?: string;
   markerMid?: string;
@@ -19,6 +19,7 @@ interface SvgNodeCommonProps {
   clipRule?: WithDefault<Int32, 0>;
   responsible?: boolean;
   display?: string;
+  pointerEvents?: string;
 }
 
 type ColorStruct = Readonly<{

--- a/src/fabric/utils.ts
+++ b/src/fabric/utils.ts
@@ -1,0 +1,5 @@
+import type { ViewProps as VP } from 'react-native';
+
+interface ViewProps extends Omit<VP, 'pointerEvents'> {}
+
+export type { ViewProps };


### PR DESCRIPTION
PR adding proper handling of `pointerEvents` in the library. Based on the comment by @RSNara : 
> For all Android components, static ViewConfigs are generated from the components types + BaseVIewConfig.android.js. The BaseViewConfig for all android components is https://github.com/facebook/react-native/blob/c5217f199dfc9db0908a5e4439b7c6b45e17a850/Libraries/NativeComponent/BaseViewConfig.android.js#L288-L297, which doesn't contain the pointerEvents validAttribute. So, React Native SVG components must re-declare the pointerEvents validAttribute. Otherwise, the pointerEvents validAttribute won't be in the static ViewConfig, which means React won't pass that prop to native with Static ViewConfigs.

We needed a way to trick `codegen` since we added our own `pointerEvents` with `string` type, and such prop is already present in `ViewProps` from `react-native`, but as a union of strings, so their types did not match. As `codegen` parses string literals, we include changed `ViewProps` type, without `pointerEvents` prop, so we satisfy both `codegen` and TS.

As for how `pointerEvents` are handled now:
- iOS:

Paper: prop is passed in RCTViewManager but it looks like it does not matter what you pass there, since even if you set none, resulting in view.userInteractionEnabled = NO; (https://github.com/facebook/react-native/blob/065db683a20b273ea3656dead29845327637669a/React/Views/RCTViewManager.m#L256), custom implementation of hitTest will not take it into account anyhow.

Fabric: we don’t use pointerEvents prop but it is not a problem since it is not used in the implementation of neither SvgView and RCTViewComponentView (it is used in hitTest method there, but we override it)

- Android:

Paper: the prop was passed through ReactViewManager and was set on the view directly. But the setter for pointerEvents is not visible outside of ReactViewGroup . After adding Fabric integration for both platforms: BaseViewManager does not implement setter for pointerEvents so we have to add the prop by ourselves. Still, we cannot call the setter from ReactViewGroup since it is not visible, so all the logic for pointerEvents should be migrated to SvgView unfortunately or we should use reflection to get that method.


Despite that, it seems that behavior differs on Android and iOS since setting pointerEvents to none on Android makes the view not clickable, whereas on iOS it does not change anything.