### PR TITLE
feat: update props field so rea works correctly

### DIFF
--- a/android/src/main/java/com/horcrux/svg/RenderableViewManager.java
+++ b/android/src/main/java/com/horcrux/svg/RenderableViewManager.java
@@ -488,20 +488,26 @@ class VirtualViewManager<V extends VirtualView> extends ViewGroupManager<Virtual
     view.setMatrix(value);
   }
 
+  @Override
+  public void setTransform(VirtualView node, @Nullable ReadableArray matrix) {
+    if (matrix == null) {
+      resetTransformProperty(node);
+    } else {
+      setTransformProperty(node, matrix);
+    }
+
+    Matrix m = node.getMatrix();
+    node.mTransform = m;
+    node.mTransformInvertible = m.invert(node.mInvTransform);
+  }
+
   @ReactProp(name = "transform")
   public void setTransform(V node, Dynamic matrix) {
     if (matrix.getType() != ReadableType.Array) {
       return;
     }
     ReadableArray ma = matrix.asArray();
-    if (ma == null) {
-      resetTransformProperty(node);
-    } else {
-      setTransformProperty(node, ma);
-    }
-    Matrix m = node.getMatrix();
-    node.mTransform = m;
-    node.mTransformInvertible = m.invert(node.mInvTransform);
+    setTransform(node, ma);
   }
 
   private void invalidateSvgView(V node) {

--- a/apple/Elements/RNSVGClipPath.mm
+++ b/apple/Elements/RNSVGClipPath.mm
@@ -41,6 +41,7 @@ using namespace facebook::react;
 {
   const auto &newProps = *std::static_pointer_cast<const RNSVGClipPathProps>(props);
   setCommonNodeProps(newProps, self);
+  _props = std::static_pointer_cast<RNSVGClipPathProps const>(props);
 }
 
 - (void)prepareForRecycle

--- a/apple/Elements/RNSVGForeignObject.mm
+++ b/apple/Elements/RNSVGForeignObject.mm
@@ -57,6 +57,7 @@ using namespace facebook::react;
   }
 
   setCommonGroupProps(newProps, self);
+  _props = std::static_pointer_cast<RNSVGForeignObjectProps const>(props);
 }
 
 - (void)prepareForRecycle

--- a/apple/Elements/RNSVGGroup.mm
+++ b/apple/Elements/RNSVGGroup.mm
@@ -46,6 +46,7 @@ using namespace facebook::react;
   const auto &newProps = *std::static_pointer_cast<const RNSVGGroupProps>(props);
 
   setCommonGroupProps(newProps, self);
+  _props = std::static_pointer_cast<RNSVGGroupProps const>(props);
 }
 
 - (void)prepareForRecycle

--- a/apple/Elements/RNSVGImage.mm
+++ b/apple/Elements/RNSVGImage.mm
@@ -93,6 +93,7 @@ using namespace facebook::react;
   self.meetOrSlice = intToRNSVGVBMOS(newProps.meetOrSlice);
 
   setCommonRenderableProps(newProps, self);
+  _props = std::static_pointer_cast<RNSVGImageProps const>(props);
 }
 
 - (void)prepareForRecycle

--- a/apple/Elements/RNSVGLinearGradient.mm
+++ b/apple/Elements/RNSVGLinearGradient.mm
@@ -65,6 +65,7 @@ using namespace facebook::react;
   }
 
   setCommonNodeProps(newProps, self);
+  _props = std::static_pointer_cast<RNSVGLinearGradientProps const>(props);
 }
 
 - (void)prepareForRecycle

--- a/apple/Elements/RNSVGMarker.mm
+++ b/apple/Elements/RNSVGMarker.mm
@@ -59,6 +59,7 @@ using namespace facebook::react;
   self.meetOrSlice = intToRNSVGVBMOS(newProps.meetOrSlice);
 
   setCommonGroupProps(newProps, self);
+  _props = std::static_pointer_cast<RNSVGMarkerProps const>(props);
 }
 
 - (void)prepareForRecycle

--- a/apple/Elements/RNSVGMask.mm
+++ b/apple/Elements/RNSVGMask.mm
@@ -64,6 +64,7 @@ using namespace facebook::react;
   }
 
   setCommonGroupProps(newProps, self);
+  _props = std::static_pointer_cast<RNSVGMaskProps const>(props);
 }
 
 - (void)prepareForRecycle

--- a/apple/Elements/RNSVGPath.mm
+++ b/apple/Elements/RNSVGPath.mm
@@ -45,6 +45,7 @@ using namespace facebook::react;
   self.d = [[RNSVGPathParser alloc] initWithPathString:RCTNSStringFromString(newProps.d)];
 
   setCommonRenderableProps(newProps, self);
+  _props = std::static_pointer_cast<RNSVGPathProps const>(props);
 }
 
 - (void)prepareForRecycle

--- a/apple/Elements/RNSVGPattern.mm
+++ b/apple/Elements/RNSVGPattern.mm
@@ -70,6 +70,7 @@ using namespace facebook::react;
   self.meetOrSlice = intToRNSVGVBMOS(newProps.meetOrSlice);
 
   setCommonGroupProps(newProps, self);
+  _props = std::static_pointer_cast<RNSVGPatternProps const>(props);
 }
 
 - (void)prepareForRecycle

--- a/apple/Elements/RNSVGRadialGradient.mm
+++ b/apple/Elements/RNSVGRadialGradient.mm
@@ -65,6 +65,7 @@ using namespace facebook::react;
   }
 
   setCommonNodeProps(newProps, self);
+  _props = std::static_pointer_cast<RNSVGRadialGradientProps const>(props);
 }
 
 - (void)prepareForRecycle

--- a/apple/Elements/RNSVGSvgView.mm
+++ b/apple/Elements/RNSVGSvgView.mm
@@ -78,6 +78,7 @@ using namespace facebook::react;
   if (RCTUIColorFromSharedColor(newProps.color)) {
     self.tintColor = RCTUIColorFromSharedColor(newProps.color);
   }
+  _props = std::static_pointer_cast<RNSVGSvgViewProps const>(props);
 }
 
 - (void)prepareForRecycle

--- a/apple/Elements/RNSVGSymbol.mm
+++ b/apple/Elements/RNSVGSymbol.mm
@@ -49,6 +49,7 @@ using namespace facebook::react;
   self.meetOrSlice = intToRNSVGVBMOS(newProps.meetOrSlice);
 
   setCommonGroupProps(newProps, self);
+  _props = std::static_pointer_cast<RNSVGSymbolProps const>(props);
 }
 
 - (void)prepareForRecycle

--- a/apple/Elements/RNSVGUse.mm
+++ b/apple/Elements/RNSVGUse.mm
@@ -53,6 +53,7 @@ using namespace facebook::react;
   self.href = RCTNSStringFromStringNilIfEmpty(newProps.href);
 
   setCommonRenderableProps(newProps, self);
+  _props = std::static_pointer_cast<RNSVGUseProps const>(props);
 }
 
 - (void)prepareForRecycle

--- a/apple/Shapes/RNSVGCircle.mm
+++ b/apple/Shapes/RNSVGCircle.mm
@@ -47,6 +47,7 @@ using namespace facebook::react;
   self.r = [RNSVGLength lengthWithString:RCTNSStringFromString(newProps.r)];
 
   setCommonRenderableProps(newProps, self);
+  _props = std::static_pointer_cast<RNSVGCircleProps const>(props);
 }
 
 - (void)prepareForRecycle

--- a/apple/Shapes/RNSVGEllipse.mm
+++ b/apple/Shapes/RNSVGEllipse.mm
@@ -48,6 +48,7 @@ using namespace facebook::react;
   self.ry = [RNSVGLength lengthWithString:RCTNSStringFromString(newProps.ry)];
 
   setCommonRenderableProps(newProps, self);
+  _props = std::static_pointer_cast<RNSVGEllipseProps const>(props);
 }
 
 - (void)prepareForRecycle

--- a/apple/Shapes/RNSVGLine.mm
+++ b/apple/Shapes/RNSVGLine.mm
@@ -48,6 +48,7 @@ using namespace facebook::react;
   self.y2 = [RNSVGLength lengthWithString:RCTNSStringFromString(newProps.y2)];
 
   setCommonRenderableProps(newProps, self);
+  _props = std::static_pointer_cast<RNSVGLineProps const>(props);
 }
 
 - (void)prepareForRecycle

--- a/apple/Shapes/RNSVGRect.mm
+++ b/apple/Shapes/RNSVGRect.mm
@@ -54,6 +54,7 @@ using namespace facebook::react;
   self.ry = [RNSVGLength lengthWithString:RCTNSStringFromString(newProps.ry)];
 
   setCommonRenderableProps(newProps, self);
+  _props = std::static_pointer_cast<RNSVGRectProps const>(props);
 }
 
 - (void)prepareForRecycle

--- a/apple/Text/RNSVGTSpan.mm
+++ b/apple/Text/RNSVGTSpan.mm
@@ -63,6 +63,7 @@ using namespace facebook::react;
   self.content = RCTNSStringFromStringNilIfEmpty(newProps.content);
 
   setCommonTextProps(newProps, self);
+  _props = std::static_pointer_cast<RNSVGTSpanProps const>(props);
 }
 
 - (void)prepareForRecycle

--- a/apple/Text/RNSVGText.mm
+++ b/apple/Text/RNSVGText.mm
@@ -52,6 +52,7 @@ using namespace facebook::react;
   const auto &newProps = *std::static_pointer_cast<const RNSVGTextProps>(props);
 
   setCommonTextProps(newProps, self);
+  _props = std::static_pointer_cast<RNSVGTextProps const>(props);
 }
 
 - (void)prepareForRecycle

--- a/apple/Text/RNSVGTextPath.mm
+++ b/apple/Text/RNSVGTextPath.mm
@@ -49,6 +49,7 @@ using namespace facebook::react;
   self.startOffset = [RNSVGLength lengthWithString:RCTNSStringFromString(newProps.startOffset)];
 
   setCommonTextProps(newProps, self);
+  _props = std::static_pointer_cast<RNSVGTextPathProps const>(props);
 }
 
 - (void)prepareForRecycle


### PR DESCRIPTION
PR adding update of `_props` after `updateProps` method in order for e.g. `react-native-reanimated` to pick correct props when running updates. Coauthored by @tomekzaw. It is needed since `RCTMountingManager` reads this field as `oldProps`: https://github.com/facebook/react-native/blob/10e47b891aad8cb1d79a2fccd68edeeefb31756f/React/Fabric/Mounting/RCTMountingManager.mm#L306