### PR TITLE
fix: make Defs pass invalidate higher even though it does not conform…

### DIFF
--- a/apple/RNSVGNode.mm
+++ b/apple/RNSVGNode.mm
@@ -71,7 +71,7 @@ CGFloat const RNSVG_DEFAULT_FONT_SIZE = 12;
   RNSVGView *container = self.superview;
   // on Fabric, when the child components are added to hierarchy and their props are set,
   // their superview is not set yet.
-  if ([container conformsToProtocol:@protocol(RNSVGContainer)]) {
+  if (container != nil) {
     [(id<RNSVGContainer>)container invalidate];
   }
   [self clearPath];


### PR DESCRIPTION
PR making `Defs` pass invalidate higher even though it does not conform to RNSVGContainer. Should fix https://github.com/react-native-svg/react-native-svg/issues/1888 Maybe it should be done another way round, making `Defs` component implement the protocol, since it does it already by having `invalidate` method.