### PR TITLE
fix: restore compatibility with react-native <0.68 (#1890)

### DIFF
--- a/android/src/main/java/com/horcrux/svg/SvgViewManager.java
+++ b/android/src/main/java/com/horcrux/svg/SvgViewManager.java
@@ -21,6 +21,7 @@ import com.facebook.react.views.view.ReactViewGroup;
 import com.facebook.react.views.view.ReactViewManager;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Locale;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -174,7 +175,8 @@ class SvgViewManager extends ReactViewManager implements RNSVGSvgViewManagerInte
       if (superclass != null) {
         Method method = superclass.getDeclaredMethod("setPointerEvents", PointerEvents.class);
         method.setAccessible(true);
-        method.invoke(view, PointerEvents.parsePointerEvents(pointerEventsStr));
+        method.invoke(
+            view, PointerEvents.valueOf(pointerEventsStr.toUpperCase(Locale.US).replace("-", "_")));
       }
     } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
       e.printStackTrace();


### PR DESCRIPTION
# Summary

Replaces `PointerEvents.parsePointerEvents(pointerEventsStr)` with `PointerEvents.valueOf(pointerEventsStr.toUpperCase(Locale.US).replace("-", "_"))`. This is the implementation of the original method.

Fixes #1890

## Testing

- Tested debug and release builds of a react-native v0.67.4 project on a physical device. Builds are successful.
- Tested the pointer events prop on the current example and with RN 0.67. Behavior is as expected.

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
